### PR TITLE
HangFire Custom Settings

### DIFF
--- a/src/Bootstrapper/appsettings.json
+++ b/src/Bootstrapper/appsettings.json
@@ -38,6 +38,39 @@
     "DBProvider": "mssql",
     "ConnectionString": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=backendDb;Integrated Security=True;MultipleActiveResultSets=True"
   },
+  "HangFireSettings": {
+    "Route": "/jobs",
+    "Dashboard": {
+      "AppPath": "/",
+      "StatsPollingInterval": 2000,
+      "DashboardTitle": "Jobs"
+    },
+    "Server": {
+      "HeartbeatInterval": "00:00:30",
+      "Queues": [ "default", "notDefault" ],
+      "SchedulePollingInterval": "00:00:15",
+      "ServerCheckInterval": "00:05:00",
+      "ServerName": null,
+      "ServerTimeout": "00:05:00",
+      "ShutdownTimeout": "00:00:15",
+      "WorkerCount": 5
+    },
+    "Storage": {
+      "StorageProvider": "mssql",
+      "ConnectionString": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=backendDb;Integrated Security=True;MultipleActiveResultSets=True",
+      "Options": {
+        "CommandBatchMaxTimeout": "00:05:00",
+        "QueuePollInterval": "00:00:00",
+        "UseRecommendedIsolationLevel": true,
+        "SlidingInvisibilityTimeout": "00:05:00",
+        "DisableGlobalLocks": true
+      }
+    },
+    "Credentiales": {
+      "User": "Admin",
+      "Password":  "S3(r3tP@55w0rd"
+    }
+  },
   "SwaggerSettings": {
     "Enable": true
   },

--- a/src/Core/Application/Settings/HangFireSettings.cs
+++ b/src/Core/Application/Settings/HangFireSettings.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace DN.WebApi.Application.Settings
+{
+
+    public class HangFireStorageSettings
+    {
+        public string StorageProvider { get; set; }
+        public string ConnectionString { get; set; }
+    }
+
+}

--- a/src/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -32,9 +32,31 @@ namespace DN.WebApi.Infrastructure.Extensions
             app.UseCors("CorsPolicy");
             app.UseAuthentication();
             app.UseAuthorization();
-            app.UseHangfireDashboard("/jobs", new DashboardOptions
+
+            var configDashboard = config.GetSection("HangFireSettings:Dashboard").Get<DashboardOptions>();
+            app.UseHangfireDashboard(config["HangFireSettings:Route"], new DashboardOptions
             {
-                DashboardTitle = "Jobs"
+                DashboardTitle = configDashboard.DashboardTitle,
+                StatsPollingInterval = configDashboard.StatsPollingInterval,
+                AppPath = configDashboard.AppPath
+
+                // ** OPtional BasicAuthAuthorizationFilter **
+                // Authorization = new[] { new BasicAuthAuthorizationFilter(
+                //    new BasicAuthAuthorizationFilterOptions {
+                //        RequireSsl = false,
+                //        SslRedirect = false,
+                //        LoginCaseSensitive = true,
+                //        Users = new []
+                //        {
+                //            new BasicAuthAuthorizationUser
+                //            {
+                //                Login = config["HangFireSettings:Credentiales:User"],
+                //                PasswordClear =  config["HangFireSettings:Credentiales:Password"]
+                //            }
+                //        }
+                //    })
+                // }
+
             });
             app.UseEndpoints(endpoints =>
             {

--- a/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -44,7 +44,18 @@ namespace DN.WebApi.Infrastructure.Extensions
             services.AddPermissions();
             services.AddIdentity(config);
             services.AddMultitenancy<TenantManagementDbContext, ApplicationDbContext>(config);
-            services.AddHangfireServer(options => options = services.GetOptions<BackgroundJobServerOptions>("Hangfire:Server"));
+            services.AddHangfireServer(options =>
+            {
+                var optionsServer = services.GetOptions<BackgroundJobServerOptions>("HangFireSettings:Server");
+                options.HeartbeatInterval = optionsServer.HeartbeatInterval;
+                options.Queues = optionsServer.Queues;
+                options.SchedulePollingInterval = optionsServer.SchedulePollingInterval;
+                options.ServerCheckInterval = optionsServer.ServerCheckInterval;
+                options.ServerName = optionsServer.ServerName;
+                options.ServerTimeout = optionsServer.ServerTimeout;
+                options.ShutdownTimeout = optionsServer.ShutdownTimeout;
+                options.WorkerCount = optionsServer.WorkerCount;
+            });
             services.AddRouting(options => options.LowercaseUrls = true);
             services.AddMiddlewares();
             services.AddSwaggerDocumentation();

--- a/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -44,17 +44,17 @@ namespace DN.WebApi.Infrastructure.Extensions
             services.AddPermissions();
             services.AddIdentity(config);
             services.AddMultitenancy<TenantManagementDbContext, ApplicationDbContext>(config);
-            services.AddHangfireServer();
+            services.AddHangfireServer(options => options = services.GetOptions<BackgroundJobServerOptions>("Hangfire:Server"));
             services.AddRouting(options => options.LowercaseUrls = true);
             services.AddMiddlewares();
             services.AddSwaggerDocumentation();
             services.AddCorsPolicy();
             services.AddApiVersioning(config =>
-           {
-               config.DefaultApiVersion = new ApiVersion(1, 0);
-               config.AssumeDefaultVersionWhenUnspecified = true;
-               config.ReportApiVersions = true;
-           });
+            {
+                config.DefaultApiVersion = new ApiVersion(1, 0);
+                config.AssumeDefaultVersionWhenUnspecified = true;
+                config.ReportApiVersions = true;
+            });
             services.AddSingleton<IStringLocalizerFactory, JsonStringLocalizerFactory>();
             return services;
         }


### PR DESCRIPTION
* Se crea una independencia de Storage de la base de datos root

En algunos escenarios es necesario utilizar un storage totalmente diferente al de la base de datos root:

Esta forma abre la oportunidad para elegir su storage dentro de las opciones que brinda HangFire como por ejemplo REDIS con el fin de reducir la latencia y sobrecarga de algunos escenarios donde se realizan miles o millones de tareas al tiempo