### PR TITLE
Get a culture string from key: Specific, Natural or Default

### DIFF
--- a/src/Bootstrapper/Localization/es-CO.json
+++ b/src/Bootstrapper/Localization/es-CO.json
@@ -1,0 +1,16 @@
+﻿{
+  "auth.failed": "Autenticación fallida",
+  "tenant.invalid": "Inquilino no válido.",
+  "tenant.expired": "La validez del inquilino ha expirado. Comuníquese con el administrador de la aplicación.",
+  "tenant.inactive": "El inquilino no está activo. Comuníquese con el administrador de la aplicación.",
+  "caching.added": "Caché agregado: {0}",
+  "caching.refreshed": "Caché actualizado: {0}",
+  "identity.usernotfound": "Usuario no encontrado",
+  "identity.usernotactive": "Usuario no activo. Póngase en contacto con el administrador",
+  "identity.emailnotconfirmed": "Correo electrónico no confirmado",
+  "identity.invalidcredentials": "Las credenciales proporcionadas no son válidas.",
+  "identity.invalidtoken": "Token no válido",
+  "entity.notfound": "{0} {1} No encontrado",
+  "product.alreadyexists": "El producto {0} ya existe",
+  "exceptionmiddleware.supportmessage": "Proporcione el ErrorId al equipo de soporte para un análisis más detallado."
+}

--- a/src/Bootstrapper/Localization/es.json
+++ b/src/Bootstrapper/Localization/es.json
@@ -1,0 +1,16 @@
+﻿{
+  "auth.failed": "Autenticación fallida",
+  "tenant.invalid": "Inquilino no válido.",
+  "tenant.expired": "La validez del inquilino ha expirado. Comuníquese con el administrador de la aplicación.",
+  "tenant.inactive": "El inquilino no está activo. Comuníquese con el administrador de la aplicación.",
+  "caching.added": "Caché agregado: {0}",
+  "caching.refreshed": "Caché actualizado: {0}",
+  "identity.usernotfound": "Usuario no encontrado",
+  "identity.usernotactive": "Usuario no activo. Póngase en contacto con el administrador",
+  "identity.emailnotconfirmed": "Correo electrónico no confirmado",
+  "identity.invalidcredentials": "Las credenciales proporcionadas no son válidas.",
+  "identity.invalidtoken": "Token no válido",
+  "entity.notfound": "{0} {1} No encontrado",
+  "product.alreadyexists": "El producto {0} ya existe",
+  "exceptionmiddleware.supportmessage": "Proporcione el ErrorId al equipo de soporte para un análisis más detallado."
+}


### PR DESCRIPTION
Neutral culture: A culture that has a specified language, but not a region. (for example "en", "es")
Specific culture: A culture that has a specified language and region. (for example "en-US", "en-GB", "es-CL")
Default culture: The culture "en-US"


When a localization file does not contain a queried string key, it is searched in its natural and later representation in the default culture.

pending to validate the middleware so that it behaves in the same way when the specific culture does not exist try to look for the native one before sending the "en-US".



```

        private static bool DoesCultureExist(string cultureName)
        {
            return CultureInfo.GetCultures(CultureTypes.AllCultures).Any(culture => string.Equals(culture.Name, cultureName, StringComparison.CurrentCultureIgnoreCase));
        }
```