### PR TITLE
Change Dependencies Caching Redis

### DIFF
--- a/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -6,9 +6,7 @@ using DN.WebApi.Infrastructure.Mappings;
 using DN.WebApi.Infrastructure.Persistence;
 using DN.WebApi.Infrastructure.Persistence.Extensions;
 using DN.WebApi.Infrastructure.Services.General;
-using DN.WebApi.Infrastructure.Tasks;
 using Hangfire;
-using Hangfire.Common;
 using Hangfire.Console.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -26,7 +24,7 @@ namespace DN.WebApi.Infrastructure.Extensions
             MapsterSettings.Configure();
             if (config.GetSection("CacheSettings:PreferRedis").Get<bool>())
             {
-                services.AddDistributedRedisCache(options =>
+                services.AddStackExchangeRedisCache(options =>
                 {
                     options.Configuration = config.GetSection("CacheSettings:RedisURL").Get<string>();
                     options.ConfigurationOptions = new StackExchange.Redis.ConfigurationOptions()

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -16,11 +16,11 @@
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
     <PackageReference Include="Hangfire.Console.Extensions" Version="1.0.5" />
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Application\Application.csproj" />


### PR DESCRIPTION
- The Caching library version is changed:
Microsoft.Extensions.Caching.Redis for Microsoft.Extensions.Caching.StackExchangeRedis to prevent the use of the StackExchange.Redis.StrongName and thus allow the use of the latest StackExchange.Redis versions.

* Clean code