### PR TITLE
generalize path so it can read both windows and unix

### DIFF
--- a/src/Infrastructure/Identity/Services/EmailTemplateService.cs
+++ b/src/Infrastructure/Identity/Services/EmailTemplateService.cs
@@ -1,6 +1,8 @@
+using System;
 using DN.WebApi.Application.Abstractions.Services.General;
 using Microsoft.Extensions.Localization;
 using System.IO;
+using System.Text;
 
 namespace DN.WebApi.Infrastructure.Identity.Services
 {
@@ -15,10 +17,15 @@ namespace DN.WebApi.Infrastructure.Identity.Services
 
         public string GenerateEmailConfirmationMail(string userName, string email, string emailVerificationUri)
         {
-            string filePath = Directory.GetCurrentDirectory() + "\\Email Templates\\email-confirmation.html";
-            StreamReader str = new StreamReader(filePath);
-            string mailText = str.ReadToEnd();
-            str.Close();
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string tmplFolder = Path.Combine(baseDirectory, "Email Templates");
+            string filePath = Path.Combine(tmplFolder, "email-confirmation.html");
+
+            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var sr = new StreamReader(fs, Encoding.Default);
+            string mailText = sr.ReadToEnd();
+            sr.Close();
+
             if (string.IsNullOrEmpty(mailText))
             {
                 return string.Format(_localizer["Please confirm your account by <a href='{0}'>clicking here</a>."], emailVerificationUri);


### PR DESCRIPTION
On linux (in my case ubuntu) netcore cannot find folder path because it refer to unknown folder in unix, try to replace "\" with "/"  works,