### PR TITLE
Remove Task.Wait() and Task.Result as that can lead to deadlocks

### DIFF
--- a/src/Infrastructure/Persistence/BaseDbContext.cs
+++ b/src/Infrastructure/Persistence/BaseDbContext.cs
@@ -54,15 +54,15 @@ namespace DN.WebApi.Infrastructure.Persistence
                 switch (dbProvider.ToLower())
                 {
                     case "postgresql":
-                        optionsBuilder.UseNpgsql(_tenantService.GetConnectionString());
+                        optionsBuilder.UseNpgsql(tenantConnectionString);
                         break;
 
                     case "mssql":
-                        optionsBuilder.UseSqlServer(_tenantService.GetConnectionString());
+                        optionsBuilder.UseSqlServer(tenantConnectionString);
                         break;
 
                     case "mysql":
-                        optionsBuilder.UseMySql(_tenantService.GetConnectionString(), ServerVersion.AutoDetect(_tenantService.GetConnectionString()));
+                        optionsBuilder.UseMySql(tenantConnectionString, ServerVersion.AutoDetect(tenantConnectionString));
                         break;
                 }
             }

--- a/src/Infrastructure/Persistence/Extensions/MultitenancyExtensions.cs
+++ b/src/Infrastructure/Persistence/Extensions/MultitenancyExtensions.cs
@@ -7,7 +7,6 @@ using DN.WebApi.Domain.Entities.Multitenancy;
 using DN.WebApi.Infrastructure.Filters.HangFire;
 using DN.WebApi.Infrastructure.Identity.Models;
 using DN.WebApi.Infrastructure.Persistence.Multitenancy;
-using DN.WebApi.Infrastructure.Services.General;
 using Hangfire;
 using Hangfire.Console;
 using Hangfire.MySql;
@@ -145,8 +144,7 @@ namespace DN.WebApi.Infrastructure.Persistence.Extensions
                     try
                     {
                         SeedRootTenant(dbContext, options);
-                        var availableTenants = dbContext.Tenants.ToListAsync().Result;
-                        foreach (var tenant in availableTenants)
+                        foreach (var tenant in dbContext.Tenants.ToList())
                         {
                             services.SetupTenantDatabase<TA>(options, tenant);
                         }
@@ -212,7 +210,7 @@ namespace DN.WebApi.Infrastructure.Persistence.Extensions
                 var rootTenant = new Tenant(MultitenancyConstants.Root.Name, MultitenancyConstants.Root.Key, MultitenancyConstants.Root.EmailAddress, options.ConnectionString);
                 rootTenant.SetValidity(DateTime.UtcNow.AddYears(1));
                 dbContext.Tenants.Add(rootTenant);
-                dbContext.SaveChangesAsync().Wait();
+                dbContext.SaveChanges();
             }
         }
     }


### PR DESCRIPTION
This was amongst others in TenantService. While I was reviewing that code I saw that a lot is happening there in the constructor, which should be regarded as a code smell. 

What's being done there apparently, is obtaining the tenant string from the current user or the querystring or the header and fetching the tenantdto from the database (or from the cache if it exists there). This seems like a lot of work to be doing in a constructor of a service. 
At first glance this seems to be code that could be moved to a filter maybe? Although that probably doesn't take care of the HangFire case... In any case I think this code should be at least in a method and not in the constructor. Only question then is... where to call that method?