### PR TITLE
removed dependency on httpContext and PerformingContext, refactor register service hangfire 

### DIFF
--- a/src/Core/Application/Abstractions/Services/General/ITenantService.cs
+++ b/src/Core/Application/Abstractions/Services/General/ITenantService.cs
@@ -9,5 +9,7 @@ namespace DN.WebApi.Application.Abstractions.Services.General
         public string GetConnectionString();
 
         public TenantDto GetCurrentTenant();
+
+        public void SetTenant(string tenant);
     }
 }

--- a/src/Core/Application/Abstractions/Services/Identity/ICurrentUser.cs
+++ b/src/Core/Application/Abstractions/Services/Identity/ICurrentUser.cs
@@ -4,7 +4,7 @@ using System.Security.Claims;
 
 namespace DN.WebApi.Application.Abstractions.Services.Identity
 {
-    public interface ICurrentUser : ITransientService
+    public interface ICurrentUser : IScopedService
     {
         string Name { get; }
 
@@ -19,5 +19,9 @@ namespace DN.WebApi.Application.Abstractions.Services.Identity
         bool IsInRole(string role);
 
         IEnumerable<Claim> GetUserClaims();
+
+        void SetUser(ClaimsPrincipal user);
+
+        void SetUserJob(string userId);
     }
 }

--- a/src/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using DN.WebApi.Infrastructure.Hubs;
+using DN.WebApi.Infrastructure.Middlewares;
 using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -32,6 +33,7 @@ namespace DN.WebApi.Infrastructure.Extensions
             app.UseRouting();
             app.UseCors("CorsPolicy");
             app.UseAuthentication();
+            app.UseMiddleware<TenantMiddleware>();
             app.UseAuthorization();
 
             var configDashboard = config.GetSection("HangFireSettings:Dashboard").Get<DashboardOptions>();

--- a/src/Infrastructure/Extensions/HangfireExtensions.cs
+++ b/src/Infrastructure/Extensions/HangfireExtensions.cs
@@ -1,0 +1,68 @@
+﻿using DN.WebApi.Application.Settings;
+using DN.WebApi.Infrastructure.Filters.HangFire;
+using DN.WebApi.Infrastructure.Persistence.Extensions;
+using Hangfire;
+using Hangfire.Console;
+using Hangfire.MySql;
+using Hangfire.PostgreSql;
+using Hangfire.SqlServer;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using System;
+
+namespace DN.WebApi.Infrastructure.Extensions
+{
+    public static class HangfireExtensions
+    {
+        private static readonly ILogger _logger = Log.ForContext(typeof(HangfireExtensions));
+
+        public static IServiceCollection AddHangFireService(this IServiceCollection services)
+        {
+            var storageSettings = services.GetOptions<HangFireStorageSettings>("HangFireSettings:Storage");
+
+            if (string.IsNullOrEmpty(storageSettings.StorageProvider)) throw new Exception("Storage HangFire Provider is not configured.");
+            _logger.Information($"Hangfire: Current Storage Provider : {storageSettings.StorageProvider}");
+            _logger.Information("For more HangFire storage, visit https://www.hangfire.io/extensions.html");
+
+            services.AddSingleton<JobActivator, ContextJobActivator>();
+
+            switch (storageSettings.StorageProvider.ToLower())
+            {
+                case "postgresql":
+                    services.AddHangfire((provider, config) =>
+                    {
+                        config.UsePostgreSqlStorage(storageSettings.ConnectionString, services.GetOptions<PostgreSqlStorageOptions>("HangFireSettings:Storage:Options"))
+                        .UseFilter(new TenantJobFilter(provider))
+                        .UseFilter(new LogJobFilter())
+                        .UseConsole();
+                    });
+                    break;
+
+                case "mssql":
+                    services.AddHangfire((provider, config) =>
+                    {
+                        config.UseSqlServerStorage(storageSettings.ConnectionString, services.GetOptions<SqlServerStorageOptions>("HangFireSettings:Storage:Options"))
+                        .UseFilter(new TenantJobFilter(provider))
+                        .UseFilter(new LogJobFilter())
+                        .UseConsole();
+                    });
+                    break;
+
+                case "mysql":
+                    services.AddHangfire((provider, config) =>
+                    {
+                        config.UseStorage(new MySqlStorage(storageSettings.ConnectionString, services.GetOptions<MySqlStorageOptions>("HangFireSettings:Storage:Options")))
+                        .UseFilter(new TenantJobFilter(provider))
+                        .UseFilter(new LogJobFilter())
+                        .UseConsole();
+                    });
+                    break;
+
+                default:
+                    throw new Exception($"HangFire Storage Provider {storageSettings.StorageProvider} is not supported.");
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/Infrastructure/Extensions/MiddlewareExtensions.cs
+++ b/src/Infrastructure/Extensions/MiddlewareExtensions.cs
@@ -2,7 +2,6 @@ using DN.WebApi.Application.Settings;
 using DN.WebApi.Infrastructure.Middlewares;
 using DN.WebApi.Infrastructure.Persistence.Extensions;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -16,6 +15,7 @@ namespace DN.WebApi.Infrastructure.Extensions
             if (config.GetValue<bool>("MiddlewareSettings:EnableHttpsLogging")) app.UseMiddleware<RequestLoggingMiddleware>();
             app.UseMiddleware<ExceptionMiddleware>();
             if (config.GetValue<bool>("MiddlewareSettings:EnableHttpsLogging")) app.UseMiddleware<ResponseLoggingMiddleware>();
+
             return app;
         }
 
@@ -25,7 +25,7 @@ namespace DN.WebApi.Infrastructure.Extensions
 
             if (middlewareSettings.EnableLocalization) services.AddSingleton<LocalizationMiddleware>();
             if (middlewareSettings.EnableHttpsLogging) services.AddSingleton<RequestLoggingMiddleware>();
-            services.AddSingleton<ExceptionMiddleware>();
+            services.AddScoped<ExceptionMiddleware>();
             if (middlewareSettings.EnableHttpsLogging) services.AddSingleton<ResponseLoggingMiddleware>();
             return services;
         }

--- a/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using DN.WebApi.Application.Abstractions.Services.General;
 using DN.WebApi.Infrastructure.Identity.Permissions;
 using DN.WebApi.Infrastructure.Localizer;
 using DN.WebApi.Infrastructure.Mappings;
+using DN.WebApi.Infrastructure.Middlewares;
 using DN.WebApi.Infrastructure.Persistence;
 using DN.WebApi.Infrastructure.Persistence.Extensions;
 using DN.WebApi.Infrastructure.Services.General;
@@ -38,6 +39,7 @@ namespace DN.WebApi.Infrastructure.Extensions
                 services.AddDistributedMemoryCache();
             }
 
+            services.AddScoped<TenantMiddleware>();
             services.TryAdd(ServiceDescriptor.Singleton<ICacheService, CacheService>());
             services.AddHealthCheckExtension();
             services.AddLocalization();
@@ -58,6 +60,7 @@ namespace DN.WebApi.Infrastructure.Extensions
                 options.WorkerCount = optionsServer.WorkerCount;
             });
             services.AddHangfireConsoleExtensions();
+            services.AddHangFireService();
             services.AddMultitenancy<TenantManagementDbContext, ApplicationDbContext>(config);
             services.AddRouting(options => options.LowercaseUrls = true);
             services.AddMiddlewares();

--- a/src/Infrastructure/Filters/HangFire/ContextJobActivator.cs
+++ b/src/Infrastructure/Filters/HangFire/ContextJobActivator.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using DN.WebApi.Application.Abstractions.Services.General;
+using DN.WebApi.Application.Abstractions.Services.Identity;
+using Hangfire;
+using Hangfire.Server;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DN.WebApi.Infrastructure.Filters.HangFire
+{
+    public class ContextJobActivator : JobActivator
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+
+        public ContextJobActivator(IServiceScopeFactory scopeFactory)
+        {
+            _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        }
+
+        public override JobActivatorScope BeginScope(PerformContext context)
+        {
+            return new Scope(context, _scopeFactory.CreateScope());
+        }
+
+        private class Scope : JobActivatorScope, IServiceProvider
+        {
+            private readonly PerformContext _context;
+            private readonly IServiceScope _scope;
+
+            public Scope(PerformContext context, IServiceScope scope)
+            {
+                _context = context ?? throw new ArgumentNullException(nameof(context));
+                _scope = scope ?? throw new ArgumentNullException(nameof(scope));
+
+                setParametersScope();
+            }
+
+            private void setParametersScope()
+            {
+                ITenantService tenantService = _scope.ServiceProvider.GetRequiredService<ITenantService>();
+                string tenant = _context.GetJobParameter<string>("tenant");
+                tenantService.SetTenant(tenant);
+
+                ICurrentUser currentUser = _scope.ServiceProvider.GetRequiredService<ICurrentUser>();
+                string userId = _context.GetJobParameter<string>("userId");
+                currentUser.SetUserJob(userId);
+
+            }
+
+            public override object Resolve(Type type)
+            {
+                return ActivatorUtilities.GetServiceOrCreateInstance(this, type);
+            }
+
+            object IServiceProvider.GetService(Type serviceType)
+            {
+                if (serviceType == typeof(PerformContext))
+                    return _context;
+                return _scope.ServiceProvider.GetService(serviceType);
+            }
+        }
+    }
+
+}

--- a/src/Infrastructure/Identity/Services/CurrentUser.cs
+++ b/src/Infrastructure/Identity/Services/CurrentUser.cs
@@ -36,7 +36,7 @@ namespace DN.WebApi.Infrastructure.Identity.Services
 
         public bool IsInRole(string role)
         {
-            return _user.IsInRole(role);
+            return _user?.IsInRole(role);
         }
 
         public IEnumerable<Claim> GetUserClaims()

--- a/src/Infrastructure/Middlewares/TenantMiddleware.cs
+++ b/src/Infrastructure/Middlewares/TenantMiddleware.cs
@@ -34,7 +34,7 @@ namespace DN.WebApi.Infrastructure.Middlewares
             }
             else
             {
-                string tenantFromQueryString = System.Web.HttpUtility.ParseQueryString(context.Request.QueryString.Value).Get("tenant");
+                string tenantFromQueryString = context.Request.Query["tenant"].First();
                 if (!string.IsNullOrEmpty(tenantFromQueryString))
                 {
                     tenantInfo.SetTenant(tenantFromQueryString);

--- a/src/Infrastructure/Middlewares/TenantMiddleware.cs
+++ b/src/Infrastructure/Middlewares/TenantMiddleware.cs
@@ -1,0 +1,55 @@
+﻿using DN.WebApi.Application.Abstractions.Services.General;
+using DN.WebApi.Application.Abstractions.Services.Identity;
+using DN.WebApi.Application.Exceptions;
+using DN.WebApi.Infrastructure.Identity.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DN.WebApi.Infrastructure.Middlewares
+{
+    public class TenantMiddleware : IMiddleware
+    {
+        private readonly IStringLocalizer<TenantMiddleware> _localizer;
+
+        public TenantMiddleware(IStringLocalizer<TenantMiddleware> localizer)
+        {
+            _localizer = localizer;
+        }
+
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            var userInfo = context.RequestServices.GetRequiredService<ICurrentUser>();
+            userInfo.SetUser(context.User);
+            var tenantInfo = context.RequestServices.GetRequiredService<ITenantService>();
+            if (userInfo.IsAuthenticated())
+            {
+                tenantInfo.SetTenant(userInfo.GetTenant());
+            }
+            else
+            {
+                string tenantFromQueryString = System.Web.HttpUtility.ParseQueryString(context.Request.QueryString.Value).Get("tenant");
+                if (!string.IsNullOrEmpty(tenantFromQueryString))
+                {
+                    tenantInfo.SetTenant(tenantFromQueryString);
+                }
+                else if (context.Request.Headers.TryGetValue("tenant", out var tenant))
+                {
+                    tenantInfo.SetTenant(tenant);
+                }
+                else
+                {
+                    throw new IdentityException(_localizer["auth.failed"], statusCode: HttpStatusCode.Unauthorized);
+                }
+            }
+
+            await next(context);
+        }
+    }
+}


### PR DESCRIPTION
* TenantService and IcurrentService are refactored, now injected from tenantMiddleware or ContextJobActivator
* Move register hangfire service to HangfireExtensions.cs
* ExceptionMiddleware changed to  services.AddScoped 
* It is exposed to the public method TenantService.SetTenant and its use is limited to initialization within the middleware or ContextJobActivator
