### PR TITLE
Auditing: add only added, deleted and modified entries to the audit trail

### DIFF
--- a/src/Infrastructure/Persistence/Contexts/BaseDbContext.cs
+++ b/src/Infrastructure/Persistence/Contexts/BaseDbContext.cs
@@ -88,7 +88,9 @@ public abstract class BaseDbContext : IdentityDbContext<ApplicationUser, Applica
     {
         ChangeTracker.DetectChanges();
         var trailEntries = new List<AuditTrail>();
-        foreach (var entry in ChangeTracker.Entries<AuditableEntity>().ToList())
+        foreach (var entry in ChangeTracker.Entries<AuditableEntity>()
+            .Where(e => e.State is EntityState.Added or EntityState.Deleted or EntityState.Modified)
+            .ToList())
         {
             var trailEntry = new AuditTrail(entry, _serializer)
             {


### PR DESCRIPTION
Otherwise too much is tracked.

E.g. When updating a product, there was also a trail entry for Brand although nothing was changed there.
