### PR TITLE
Add AzureAD support

### DIFF
--- a/src/Core/Application/Identity/Interfaces/IIdentityService.cs
+++ b/src/Core/Application/Identity/Interfaces/IIdentityService.cs
@@ -1,11 +1,15 @@
 using DN.WebApi.Application.Common.Interfaces;
 using DN.WebApi.Application.Wrapper;
 using DN.WebApi.Shared.DTOs.Identity;
+using System.Security.Claims;
 
 namespace DN.WebApi.Application.Identity.Interfaces;
 
 public interface IIdentityService : ITransientService
 {
+    // Returns the UserId
+    Task<string> GetOrCreateFromPrincipalAsync(ClaimsPrincipal principal);
+
     Task<IResult> RegisterAsync(RegisterRequest request, string origin);
 
     Task<IResult<string>> ConfirmEmailAsync(string userId, string code, string tenant);

--- a/src/Core/Application/Multitenancy/ITenantManager.cs
+++ b/src/Core/Application/Multitenancy/ITenantManager.cs
@@ -8,6 +8,8 @@ public interface ITenantManager : ITransientService
 {
     public Task<Result<TenantDto>> GetByKeyAsync(string key);
 
+    public Task<Result<TenantDto>> GetByIssuerAsync(string issuer);
+
     public Task<Result<List<TenantDto>>> GetAllAsync();
 
     public Task<Result<object>> CreateTenantAsync(CreateTenantRequest request);

--- a/src/Core/Domain/Multitenancy/Tenant.cs
+++ b/src/Core/Domain/Multitenancy/Tenant.cs
@@ -12,6 +12,8 @@ public class Tenant : AuditableEntity
     public bool IsActive { get; private set; }
     public DateTime ValidUpto { get; private set; }
 
+    public string? Issuer { get; set; }
+
     public Tenant(string? name, string? key, string? adminEmail, string? connectionString)
     {
         Name = name;

--- a/src/Host/Configurations/security.json
+++ b/src/Host/Configurations/security.json
@@ -1,7 +1,23 @@
 {
-  "JwtSettings": {
-    "key": "S0M3RAN0MS3CR3T!1!MAG1C!1!",
-    "tokenExpirationInMinutes": 60,
-    "refreshTokenExpirationInDays": 7
+  "SecuritySettings": {
+    "Provider": "Jwt",
+    "JwtSettings": {
+      "key": "S0M3RAN0MS3CR3T!1!MAG1C!1!",
+      "tokenExpirationInMinutes": 60,
+      "refreshTokenExpirationInDays": 7
+    },
+    "AzureAd": {
+      "Instance": "https://login.microsoftonline.com/",
+      "Domain": "<YourDomain>.onmicrosoft.com",
+      "TenantId": "organizations",
+      "ClientId": "<YourClientIdOfTheApiAppRegistration>",
+      "Scopes": "access_as_user"
+    },
+    "Swagger": {
+      "AuthorizationUrl": "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize",
+      "TokenUrl": "https://login.microsoftonline.com/organizations/oauth2/v2.0/token",
+      "ApiScope": "api://<YourClientIdOfTheApiAppRegistration>/access_as_user",
+      "OpenIdClientId": "<YourClientIdOfTheSwaggerAppRegistration>"
+    }
   }
 }

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -1,6 +1,7 @@
 using DN.WebApi.Application;
 using DN.WebApi.Host.Configurations;
 using DN.WebApi.Infrastructure;
+using DN.WebApi.Infrastructure.Multitenancy;
 using FluentValidation.AspNetCore;
 using Serilog;
 
@@ -19,7 +20,10 @@ try
 
     var app = builder.Build();
 
+    DatabaseInitializer.InitializeDatabases(app.Services);
+
     app.UseInfrastructure(builder.Configuration);
+
     app.Run();
 }
 catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", StringComparison.Ordinal))

--- a/src/Infrastructure/Identity/AzureAd/AzureAdClaimTypes.cs
+++ b/src/Infrastructure/Identity/AzureAd/AzureAdClaimTypes.cs
@@ -1,0 +1,6 @@
+﻿namespace DN.WebApi.Infrastructure.Identity.AzureAd;
+
+internal static class AzureADClaimTypes
+{
+    public const string ObjectId = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+}

--- a/src/Infrastructure/Identity/AzureAd/AzureAdJwtBearerEvents.cs
+++ b/src/Infrastructure/Identity/AzureAd/AzureAdJwtBearerEvents.cs
@@ -1,0 +1,122 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Security.Claims;
+using DN.WebApi.Application.Identity.Exceptions;
+using DN.WebApi.Application.Identity.Interfaces;
+using DN.WebApi.Application.Multitenancy;
+using DN.WebApi.Infrastructure.Identity.Extensions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web;
+using Serilog;
+
+namespace DN.WebApi.Infrastructure.Identity.AzureAd;
+
+internal class AzureAdJwtBearerEvents : JwtBearerEvents
+{
+    private readonly ILogger _logger;
+
+    public AzureAdJwtBearerEvents(ILogger logger) => _logger = logger;
+
+    public override Task AuthenticationFailed(AuthenticationFailedContext context)
+    {
+        _logger.AuthenticationFailed(context.Exception);
+        return base.AuthenticationFailed(context);
+    }
+
+    public override Task MessageReceived(MessageReceivedContext context)
+    {
+        _logger.TokenReceived();
+        return base.MessageReceived(context);
+    }
+
+    /// <summary>
+    /// This method contains the logic that validates the user's tenant and normalizes claims.
+    /// </summary>
+    /// <param name="context">The validated token context.</param>
+    /// <returns>A task.</returns>
+    public override async Task TokenValidated(TokenValidatedContext context)
+    {
+        var principal = context.Principal;
+
+        (string issuer, string objectId, string tenantKey) =
+            await GetValuesFromPrincipal(principal, context.HttpContext.RequestServices);
+
+        // the caller comes from an admin-consented, recorded issuer
+        var identity = principal.Identities.First();
+
+        // Adding tenant claim
+        identity.AddClaim(new Claim("tenant", tenantKey));
+
+        // Creating a new scope and set the new tenant key so it gets picked up
+        using var scope = context.HttpContext.RequestServices.CreateScope();
+
+        scope.ServiceProvider.GetRequiredService<ITenantService>().SetCurrentTenant(tenantKey);
+
+        // Lookup local user or create one if none exist.
+        var identityService = scope.ServiceProvider.GetRequiredService<IIdentityService>();
+        string userId = await identityService.GetOrCreateFromPrincipalAsync(principal);
+
+        // we use the nameidentifier claim to store the user id
+        var idClaim = principal.FindFirst(ClaimTypes.NameIdentifier);
+        identity.TryRemoveClaim(idClaim);
+        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, userId));
+
+        // and the email claim for the email
+        var emailClaim = principal.FindFirst(ClaimTypes.Email);
+        var upnClaim = principal.FindFirst(ClaimTypes.Upn);
+        if (upnClaim is not null)
+        {
+            identity.TryRemoveClaim(emailClaim);
+            identity.AddClaim(new Claim(ClaimTypes.Email, upnClaim.Value));
+        }
+
+        _logger.TokenValidationSucceeded(objectId, issuer);
+    }
+
+    private async Task<(string Issuer, string ObjectId, string TenantKey)> GetValuesFromPrincipal(
+        [NotNull] ClaimsPrincipal? principal, IServiceProvider serviceProvider)
+    {
+        string? issuer = principal?.GetIssuer();
+        string? objectId = principal?.GetObjectId();
+        if (principal is null || issuer is null || objectId is null)
+        {
+            _logger.TokenValidationFailed(objectId, issuer);
+            throw new IdentityException("Authentication Failed.", statusCode: HttpStatusCode.Unauthorized);
+        }
+
+        using var tenantScope = serviceProvider.CreateScope();
+
+        // creating a scope otherwise the current scope gets polluted with an ApplicationDbContext without a tenant set
+        var tenantManager = tenantScope.ServiceProvider.GetRequiredService<ITenantManager>();
+
+        var tenantResult = await tenantManager.GetByIssuerAsync(issuer);
+        if (!tenantResult.Succeeded || tenantResult.Data is null || tenantResult.Data.Key is null)
+        {
+            _logger.TokenValidationFailed(objectId, issuer);
+
+            // the caller was not from a trusted issuer - throw to block the authentication flow
+            throw new IdentityException("Authentication Failed.", statusCode: HttpStatusCode.Unauthorized);
+        }
+
+        return (issuer, objectId, tenantResult.Data.Key);
+    }
+}
+
+internal static class AzureAdJwtBearerEventsLoggingExtensions
+{
+    public static void AuthenticationFailed(this ILogger logger, Exception e) =>
+        logger.Error("Authentication failed Exception: {e}", e);
+
+    public static void TokenReceived(this ILogger logger) =>
+        logger.Information("Received a bearer token");
+
+    public static void TokenValidationStarted(this ILogger logger, string userId, string issuer) =>
+        logger.Information("Token Validation Started for User: {userId} Issuer: {issuer}", userId, issuer);
+
+    public static void TokenValidationFailed(this ILogger logger, string? userId, string? issuer) =>
+        logger.Warning("Tenant is not registered User: {userId} Issuer: {issuer}", userId, issuer);
+
+    public static void TokenValidationSucceeded(this ILogger logger, string userId, string issuer) =>
+        logger.Information("Token validation succeeded: User: {userId} Issuer: {issuer}", userId, issuer);
+}

--- a/src/Infrastructure/Identity/AzureAd/OpenIdClaimTypes.cs
+++ b/src/Infrastructure/Identity/AzureAd/OpenIdClaimTypes.cs
@@ -1,0 +1,6 @@
+﻿namespace DN.WebApi.Infrastructure.Identity.AzureAd;
+
+internal static class OpenIdConnectClaimTypes
+{
+    public const string Issuer = "iss";
+}

--- a/src/Infrastructure/Identity/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Infrastructure/Identity/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,39 +1,27 @@
+using DN.WebApi.Infrastructure.Identity.AzureAd;
 using System.Security.Claims;
 
 namespace DN.WebApi.Infrastructure.Identity.Extensions;
 
 public static class ClaimsPrincipalExtensions
 {
-    public static string? GetUserId(this ClaimsPrincipal principal)
+    public static string? GetUserId(this ClaimsPrincipal principal) =>
+        principal.FindFirstValue(ClaimTypes.NameIdentifier);
+
+    public static string? GetUserEmail(this ClaimsPrincipal principal) =>
+        principal.FindFirstValue(ClaimTypes.Email);
+
+    public static string? GetTenant(this ClaimsPrincipal principal) =>
+        principal.FindFirstValue("tenant");
+
+    public static string? GetIssuer(this ClaimsPrincipal principal)
     {
-        if (principal == null)
+        if (principal.FindFirstValue(OpenIdConnectClaimTypes.Issuer) is string issuer)
         {
-            throw new ArgumentNullException(nameof(principal));
+            return issuer;
         }
 
-        var claim = principal.FindFirst(ClaimTypes.NameIdentifier);
-        return claim?.Value;
-    }
-
-    public static string? GetUserEmail(this ClaimsPrincipal principal)
-    {
-        if (principal == null)
-        {
-            throw new ArgumentNullException(nameof(principal));
-        }
-
-        var claim = principal.FindFirst(ClaimTypes.Email);
-        return claim?.Value;
-    }
-
-    public static string? GetTenant(this ClaimsPrincipal principal)
-    {
-        if (principal == null)
-        {
-            throw new ArgumentNullException(nameof(principal));
-        }
-
-        var claim = principal.FindFirst("tenant");
-        return claim?.Value;
+        // Workaround to deal with missing "iss" claim. We search for the ObjectId claim instead and return the value of Issuer property of that Claim
+        return principal.FindFirst(AzureADClaimTypes.ObjectId)?.Issuer;
     }
 }

--- a/src/Infrastructure/Identity/Models/ApplicationUser.cs
+++ b/src/Infrastructure/Identity/Models/ApplicationUser.cs
@@ -12,4 +12,6 @@ public class ApplicationUser : IdentityUser, IIdentityTenant
     public string? RefreshToken { get; set; }
     public DateTime RefreshTokenExpiryTime { get; set; }
     public string? Tenant { get; set; }
+
+    public string? ObjectId { get; set; }
 }

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -30,6 +30,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Identity.Web" Version="1.21.1" />
         <PackageReference Include="MimeKit" Version="2.15.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.1" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />

--- a/src/Infrastructure/Middleware/Startup.cs
+++ b/src/Infrastructure/Middleware/Startup.cs
@@ -17,7 +17,7 @@ internal static class Startup
         if (GetMiddlewareSettings(config).EnableHttpsLogging)
         {
             services.AddSingleton<RequestLoggingMiddleware>();
-            services.AddSingleton<ResponseLoggingMiddleware>();
+            services.AddScoped<ResponseLoggingMiddleware>();
         }
 
         return services;

--- a/src/Infrastructure/Multitenancy/DatabaseInitializer.cs
+++ b/src/Infrastructure/Multitenancy/DatabaseInitializer.cs
@@ -1,0 +1,78 @@
+﻿using DN.WebApi.Application.Common.Interfaces;
+using DN.WebApi.Application.Multitenancy;
+using DN.WebApi.Domain.Constants;
+using DN.WebApi.Domain.Multitenancy;
+using DN.WebApi.Infrastructure.Identity.Models;
+using DN.WebApi.Infrastructure.Persistence.Contexts;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Serilog;
+
+namespace DN.WebApi.Infrastructure.Multitenancy;
+
+public static class DatabaseInitializer
+{
+    private static readonly ILogger _logger = Log.ForContext(typeof(DatabaseInitializer));
+
+    public static void InitializeDatabases(IServiceProvider serviceProvider)
+    {
+        using var scope = serviceProvider.CreateScope();
+
+        var dbContext = scope.ServiceProvider.GetRequiredService<TenantManagementDbContext>();
+
+        if (dbContext.Database.GetPendingMigrations().Any())
+        {
+            _logger.Information("Applying Root Migrations.");
+            dbContext.Database.Migrate();
+        }
+
+        var dbSettings = scope.ServiceProvider.GetRequiredService<IOptions<DatabaseSettings>>().Value;
+
+        SeedRootTenant(dbContext, dbSettings.ConnectionString!);
+
+        foreach (var tenant in dbContext.Tenants.ToList())
+        {
+            InitializeTenantDatabase(serviceProvider, dbSettings.DBProvider!, dbSettings.ConnectionString!, tenant);
+        }
+
+        _logger.Information("For documentations and guides, visit https://www.fullstackhero.net");
+        _logger.Information("To Sponsor this project, visit https://opencollective.com/fullstackhero");
+    }
+
+    private static void InitializeTenantDatabase(IServiceProvider serviceProvider, string dbProvider, string rootConnectionString, Tenant tenant)
+    {
+        if (tenant.Key is null)
+        {
+            throw new InvalidOperationException("Invalid tenant key.");
+        }
+
+        using var scope = serviceProvider.CreateScope();
+
+        // First set current tenant so the right connectionstring is used
+        var tenantService = scope.ServiceProvider.GetRequiredService<ITenantService>();
+        tenantService.SetCurrentTenant(tenant.Key);
+
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<ApplicationRole>>();
+        var seeders = scope.ServiceProvider.GetServices<IDatabaseSeeder>().ToList();
+        TenantBootstrapper.Initialize(dbContext, dbProvider, rootConnectionString, tenant, userManager, roleManager, seeders);
+    }
+
+    private static void SeedRootTenant(TenantManagementDbContext dbContext, string connectionString)
+    {
+        if (!dbContext.Tenants.Any(t => t.Key == MultitenancyConstants.Root.Key))
+        {
+            var rootTenant = new Tenant(
+                MultitenancyConstants.Root.Name,
+                MultitenancyConstants.Root.Key,
+                MultitenancyConstants.Root.EmailAddress,
+                connectionString);
+            rootTenant.SetValidity(DateTime.UtcNow.AddYears(1));
+            dbContext.Tenants.Add(rootTenant);
+            dbContext.SaveChanges();
+        }
+    }
+}

--- a/src/Infrastructure/Multitenancy/Startup.cs
+++ b/src/Infrastructure/Multitenancy/Startup.cs
@@ -1,10 +1,5 @@
-using DN.WebApi.Application.Common.Interfaces;
-using DN.WebApi.Domain.Constants;
-using DN.WebApi.Domain.Multitenancy;
-using DN.WebApi.Infrastructure.Identity.Models;
 using DN.WebApi.Infrastructure.Persistence.Contexts;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,85 +28,24 @@ internal static class Startup
         if (string.IsNullOrEmpty(dbProvider)) throw new InvalidOperationException("DB Provider is not configured.");
         _logger.Information($"Current DB Provider : {dbProvider}");
 
-        services.AddDbContext<TenantManagementDbContext>(dbProvider, rootConnectionString);
-
-        var scope = services.BuildServiceProvider().CreateScope();
-        var dbContext = scope.ServiceProvider.GetRequiredService<TenantManagementDbContext>();
-
-        if (dbContext.Database.GetPendingMigrations().Any())
-        {
-            _logger.Information("Applying Root Migrations.");
-            dbContext.Database.Migrate();
-        }
-
-        SeedRootTenant(dbContext, rootConnectionString);
-
-        foreach (var tenant in dbContext.Tenants.ToList())
-        {
-            services.SetupTenantDatabase(dbProvider, rootConnectionString, tenant);
-        }
-
-        _logger.Information("For documentations and guides, visit https://www.fullstackhero.net");
-        _logger.Information("To Sponsor this project, visit https://opencollective.com/fullstackhero");
-        return services;
+        return services
+            .AddDbContext<TenantManagementDbContext>(m => m.UseDatabase(dbProvider, rootConnectionString))
+            .AddDbContext<ApplicationDbContext>(m => m.UseDatabase(dbProvider, rootConnectionString));
     }
 
-    private static IServiceCollection AddDbContext<TContext>(this IServiceCollection services, string dbProvider, string rootConnectionString)
-        where TContext : DbContext
-    {
-        switch (dbProvider.ToLower())
+    private static DbContextOptionsBuilder UseDatabase(this DbContextOptionsBuilder builder, string dbProvider, string connectionString) =>
+        dbProvider.ToLower() switch
         {
-            case "postgresql":
-                services.AddDbContext<TContext>(m => m.UseNpgsql(rootConnectionString, e => e.MigrationsAssembly("Migrators.PostgreSQL")));
-                break;
-
-            case "mssql":
-                services.AddDbContext<TContext>(m => m.UseSqlServer(rootConnectionString, e => e.MigrationsAssembly("Migrators.MSSQL")));
-                break;
-
-            case "mysql":
-                services.AddDbContext<TContext>(m => m.UseMySql(rootConnectionString, ServerVersion.AutoDetect(rootConnectionString), e =>
-                {
-                    e.MigrationsAssembly("Migrators.MySQL");
-                    e.SchemaBehavior(MySqlSchemaBehavior.Ignore);
-                }));
-                break;
-
-            default:
-                throw new Exception($"DB Provider {dbProvider} is not supported.");
-        }
-
-        return services;
-    }
-
-    private static void SeedRootTenant<T>(T dbContext, string connectionString)
-    where T : TenantManagementDbContext
-    {
-        if (!dbContext.Tenants.Any(t => t.Key == MultitenancyConstants.Root.Key))
-        {
-            var rootTenant = new Tenant(
-                MultitenancyConstants.Root.Name,
-                MultitenancyConstants.Root.Key,
-                MultitenancyConstants.Root.EmailAddress,
-                connectionString);
-            rootTenant.SetValidity(DateTime.UtcNow.AddYears(1));
-            dbContext.Tenants.Add(rootTenant);
-            dbContext.SaveChanges();
-        }
-    }
-
-    private static IServiceCollection SetupTenantDatabase(this IServiceCollection services, string dbProvider, string rootConnectionString, Tenant tenant)
-    {
-        string tenantConnectionString = string.IsNullOrEmpty(tenant.ConnectionString) ? rootConnectionString : tenant.ConnectionString;
-
-        services.AddDbContext<ApplicationDbContext>(dbProvider, tenantConnectionString);
-
-        var scope = services.BuildServiceProvider().CreateScope();
-        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<ApplicationRole>>();
-        var seeders = scope.ServiceProvider.GetServices<IDatabaseSeeder>().ToList();
-        TenantBootstrapper.Initialize(dbContext, dbProvider, rootConnectionString, tenant, userManager, roleManager, seeders);
-        return services;
-    }
+            "postgresql" =>
+                builder.UseNpgsql(connectionString, e => e.MigrationsAssembly("Migrators.PostgreSQL")),
+            "mssql" =>
+                builder.UseSqlServer(connectionString, e => e.MigrationsAssembly("Migrators.MSSQL")),
+            "mysql" =>
+                builder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), e =>
+                    {
+                        e.MigrationsAssembly("Migrators.MySQL");
+                        e.SchemaBehavior(MySqlSchemaBehavior.Ignore);
+                    }),
+            _ => throw new Exception($"DB Provider {dbProvider} is not supported.")
+        };
 }

--- a/src/Infrastructure/Multitenancy/TenantManager.cs
+++ b/src/Infrastructure/Multitenancy/TenantManager.cs
@@ -49,6 +49,19 @@ public class TenantManager : ITenantManager
         return await Result<TenantDto>.SuccessAsync(tenantDto);
     }
 
+    public async Task<Result<TenantDto>> GetByIssuerAsync(string issuer)
+    {
+        var tenant = await _context.Tenants.Where(t => t.Issuer == issuer).FirstOrDefaultAsync();
+        var tenantDto = tenant!.Adapt<TenantDto>();
+
+        if (tenantDto is null)
+        {
+            return await Result<TenantDto>.FailAsync();
+        }
+
+        return await Result<TenantDto>.SuccessAsync(tenantDto);
+    }
+
     public async Task<Result<List<TenantDto>>> GetAllAsync()
     {
         var tenants = await _context.Tenants.ToListAsync();

--- a/src/Infrastructure/Persistence/Contexts/BaseDbContext.cs
+++ b/src/Infrastructure/Persistence/Contexts/BaseDbContext.cs
@@ -34,7 +34,7 @@ public abstract class BaseDbContext : IdentityDbContext<ApplicationUser, Applica
     {
         base.OnModelCreating(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(GetType().Assembly);
-        modelBuilder.ApplyIdentityConfiguration(_tenantService);
+        modelBuilder.ApplyIdentityConfiguration();
         modelBuilder.AppendGlobalQueryFilter<IMustHaveTenant>(b => b.Tenant == Tenant)
                     .AppendGlobalQueryFilter<ISoftDelete>(s => s.DeletedOn == null)
                     .AppendGlobalQueryFilter<IIdentityTenant>(b => b.Tenant == Tenant);

--- a/src/Infrastructure/Persistence/Contexts/TenantManagementDbContext.cs
+++ b/src/Infrastructure/Persistence/Contexts/TenantManagementDbContext.cs
@@ -11,4 +11,13 @@ public class TenantManagementDbContext : DbContext
     }
 
     public DbSet<Tenant> Tenants => Set<Tenant>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Tenant>()
+            .Property(t => t.Issuer)
+            .HasMaxLength(256);
+    }
 }

--- a/src/Infrastructure/Persistence/ModelBuilderExtensions.cs
+++ b/src/Infrastructure/Persistence/ModelBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using System.Linq.Expressions;
-using DN.WebApi.Application.Multitenancy;
 using DN.WebApi.Infrastructure.Identity.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -10,11 +9,12 @@ namespace DN.WebApi.Infrastructure.Persistence;
 
 public static class ModelBuilderExtensions
 {
-    public static void ApplyIdentityConfiguration(this ModelBuilder builder, ITenantService tenantService)
+    public static void ApplyIdentityConfiguration(this ModelBuilder builder)
     {
         builder.Entity<ApplicationUser>(entity =>
         {
             entity.ToTable("Users", "Identity");
+            entity.Property(u => u.ObjectId).HasMaxLength(256);
         });
         builder.Entity<ApplicationRole>(entity =>
         {

--- a/src/Infrastructure/Seeding/BrandSeeder.cs
+++ b/src/Infrastructure/Seeding/BrandSeeder.cs
@@ -31,7 +31,7 @@ public class BrandSeeder : IDatabaseSeeder
 
                 // Here you can use your own logic to populate the database.
                 // As an example, I am using a JSON file to populate the database.
-                string brandData = await File.ReadAllTextAsync(path + "/seeders/brands.json");
+                string brandData = await File.ReadAllTextAsync(path + "/seeding/brands.json");
                 var brands = _serializerService.Deserialize<List<Brand>>(brandData);
 
                 if (brands != null)

--- a/src/Infrastructure/Startup.cs
+++ b/src/Infrastructure/Startup.cs
@@ -53,7 +53,6 @@ public static class Startup
             .UseStaticFiles()
             .UseFileStorage()
             .UseExceptionMiddleware()
-            .UseRequestLogging(config)
             .UseLocalization(config)
             .UseRouting()
             .UseCorsPolicy()
@@ -61,6 +60,7 @@ public static class Startup
             .UseCurrentUser()
             .UseCurrentTenant()
             .UseAuthorization()
+            .UseRequestLogging(config)
             .UseHangfireDashboard(config)
             .UseEndpoints(endpoints =>
             {

--- a/src/Infrastructure/Swagger/AddTenantIdFilter.cs
+++ b/src/Infrastructure/Swagger/AddTenantIdFilter.cs
@@ -11,7 +11,7 @@ public class AddTenantIdFilter : IOperationFilter
     {
         operation.Parameters ??= new List<OpenApiParameter>();
 
-        if (context.MethodInfo.GetCustomAttribute(typeof(SwaggerHeaderAttribute)) is SwaggerHeaderAttribute attribute)
+        if (context.MethodInfo?.GetCustomAttribute(typeof(SwaggerHeaderAttribute)) is SwaggerHeaderAttribute attribute)
         {
             var existingParam = operation.Parameters.FirstOrDefault(p =>
                 p.In == ParameterLocation.Header && p.Name == attribute.HeaderName);

--- a/src/Migrators/Migrators.MSSQL/Migrations/Application/20211208235008_UserAddObjectId.Designer.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/Application/20211208235008_UserAddObjectId.Designer.cs
@@ -4,6 +4,7 @@ using DN.WebApi.Infrastructure.Persistence.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Migrators.MSSQL.Migrations.Application
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211208235008_UserAddObjectId")]
+    partial class UserAddObjectId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrators/Migrators.MSSQL/Migrations/Application/20211208235008_UserAddObjectId.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/Application/20211208235008_UserAddObjectId.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Migrators.MSSQL.Migrations.Application;
+
+public partial class UserAddObjectId : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "ObjectId",
+            schema: "Identity",
+            table: "Users",
+            type: "nvarchar(256)",
+            maxLength: 256,
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "ObjectId",
+            schema: "Identity",
+            table: "Users");
+    }
+}

--- a/src/Migrators/Migrators.MSSQL/Migrations/Root/20211208234945_TenantAddIsuer.Designer.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/Root/20211208234945_TenantAddIsuer.Designer.cs
@@ -4,6 +4,7 @@ using DN.WebApi.Infrastructure.Persistence.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Migrators.MSSQL.Migrations.Root
 {
     [DbContext(typeof(TenantManagementDbContext))]
-    partial class TenantManagementDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211208234945_TenantAddIsuer")]
+    partial class TenantAddIsuer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrators/Migrators.MSSQL/Migrations/Root/20211208234945_TenantAddIsuer.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/Root/20211208234945_TenantAddIsuer.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Migrators.MSSQL.Migrations.Root;
+
+public partial class TenantAddIsuer : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "Issuer",
+            table: "Tenants",
+            type: "nvarchar(256)",
+            maxLength: 256,
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Issuer",
+            table: "Tenants");
+    }
+}


### PR DESCRIPTION
So, the `security.json` configuration file has changed a bit. It now has a top level `SecuritySettings` with underneath it the `JwtSettings` (which were before at the top level).
Under `SecuritySettings` there is a new setting `Provider`, together with the subgroups `AzureAd` and `Swagger`. When the value of `Provider` is not `AzureAd` (case insensitive) everything works like it did before with our own token endpoints and the `JwtSettings` settings.

When `Provider` is set to `AzureAd`, the `AzureAd` and `Swagger` sub settings become important (and the `JwtSettings` not anymore).

It even supports logging in via swagger OIDC. I still need to look into getting it working with postman, but I'm sure that's possible as well.

For it to work you need to create 2 "App Registrations" under your AzureAd tenant. One for the Api, and one for the Swagger Client. The Api App needs to expose an Api by adding a scope `access_as_user`. It also needs to define app roles, one for each role in the application. When users are assigned a role in AzureAd, they will automatically get that role in the application.
The Swagger Client App needs to have permissions for the Api App `access_as_user` scope, (and probably also `User.Read` scope from Microsoft Graph). Under "Authentication" it also needs a "Single-page application" platform with redirectUri `https://localhost:7014/swagger/oauth2-redirect.html`.
You will have to fill out some id's of those apps in the `AzureAd` and `Swagger` sub settings in `security.json`.

Then there's 2 new fields in the database, one `Issuer` field in the `TenantManagementDbContext`'s `Tenant` entity and one `ObjectId` field in the `ApplicationDbContext`'s `ApplicationUser` entity. Those fields couple the tenants and users with the tenants and users from AzureAd.

So to get started you will have to manually update the Issuer field of the root tenant to have the right value, which will be in the form of `https://sts.windows.net/<YourTenantIdInAzureAd>/`. (We can maybe make that a setting under `SecuritySettings` so this won't have to be done manually?)

When a request with a bearer token comes in, first the issuer in the token is checked against the tenants in our database. If it doesn't exist a `401 UnAuthenticated` is returned. Then the `ObjectId` in the token is checked against the users in our database. If it doesn't already exist, it is created and its `ObjectId` is filled out, or if there already exists a user with the same email address or username that user's `ObjectId` is updated. The user also gets assigned a role if the role claim exists and the role exists in our database and the user doesn't already have that role assigned.

This will have to be taken up in the docs somewhere ;-)

I have only created migrations for MSSQL for now...