### PR TITLE
Cleanup repositoryasync

### DIFF
--- a/src/Infrastructure/Multitenancy/Startup.cs
+++ b/src/Infrastructure/Multitenancy/Startup.cs
@@ -1,6 +1,4 @@
 using DN.WebApi.Infrastructure.Persistence.Contexts;
-using DN.WebApi.Shared.DTOs.Multitenancy;
-using Mapster;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/src/Migrators/Migrators.MSSQL/Migrations/Application/20211212021306_Initial.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/Application/20211212021306_Initial.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Migrators/Migrators.MSSQL/Migrations/Root/20211212021332_Initial.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/Root/20211212021332_Initial.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Migrators/Migrators.MySQL/Migrations/Application/20211212021539_Initial.cs
+++ b/src/Migrators/Migrators.MySQL/Migrations/Application/20211212021539_Initial.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Metadata;
+﻿using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/src/Migrators/Migrators.MySQL/Migrations/Root/20211212021522_Initial.cs
+++ b/src/Migrators/Migrators.MySQL/Migrations/Root/20211212021522_Initial.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Migrators/Migrators.Oracle/Migrations/Application/20211211041629_initial.cs
+++ b/src/Migrators/Migrators.Oracle/Migrations/Application/20211211041629_initial.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Migrators/Migrators.Oracle/Migrations/Root/20211211041552_initial.cs
+++ b/src/Migrators/Migrators.Oracle/Migrations/Root/20211211041552_initial.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Migrators/Migrators.PostgreSQL/Migrations/Application/20211212021703_Initial.cs
+++ b/src/Migrators/Migrators.PostgreSQL/Migrations/Application/20211212021703_Initial.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable

--- a/src/Migrators/Migrators.PostgreSQL/Migrations/Root/20211212021725_Initial.cs
+++ b/src/Migrators/Migrators.PostgreSQL/Migrations/Root/20211212021725_Initial.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/tests/Infrastructure.Test/Caching/DistributedCacheService.cs
+++ b/tests/Infrastructure.Test/Caching/DistributedCacheService.cs
@@ -1,5 +1,4 @@
-﻿using DN.WebApi.Infrastructure.Caching;
-using DN.WebApi.Infrastructure.Common.Services;
+﻿using DN.WebApi.Infrastructure.Common.Services;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -10,8 +9,7 @@ namespace Infrastructure.Test.Caching;
 public class DistributedCacheService : CacheService<DN.WebApi.Infrastructure.Caching.DistributedCacheService>
 {
     protected override DN.WebApi.Infrastructure.Caching.DistributedCacheService CreateCacheService() =>
-        new(
-            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+        new(new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
             new NewtonSoftService(),
             NullLogger<DN.WebApi.Infrastructure.Caching.DistributedCacheService>.Instance);
 }

--- a/tests/Infrastructure.Test/Caching/LocalCacheService.cs
+++ b/tests/Infrastructure.Test/Caching/LocalCacheService.cs
@@ -1,5 +1,4 @@
-﻿using DN.WebApi.Infrastructure.Caching;
-using Microsoft.Extensions.Caching.Memory;
+﻿using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Infrastructure.Test.Caching;
@@ -7,7 +6,6 @@ namespace Infrastructure.Test.Caching;
 public class LocalCacheService : CacheService<DN.WebApi.Infrastructure.Caching.LocalCacheService>
 {
     protected override DN.WebApi.Infrastructure.Caching.LocalCacheService CreateCacheService() =>
-        new(
-            new MemoryCache(new MemoryCacheOptions()),
+        new(new MemoryCache(new MemoryCacheOptions()),
             NullLogger<DN.WebApi.Infrastructure.Caching.LocalCacheService>.Instance);
 }


### PR DESCRIPTION
I cleaned up RepositoryAsync a bit.

One thing I'm not sure about is the asNoTracking, which was made default true everywhere. I have now made it true for the getlist queries, an for the getsingle queries where a projection is done. 

One option to make this more clear is to split up the IRepository in an IReadRepository and an IWriteRepository where the ReadRepository is only doing asnotracking queries.
That's more of a CQRS thing though, where the IReadRepository is injected into Queries and the IWriteRepository into commands, but would probably not be bad to adopt here anyways.