### PR TITLE
Login: add server side validation

### DIFF
--- a/src/Host/Controllers/Identity/TokensController.cs
+++ b/src/Host/Controllers/Identity/TokensController.cs
@@ -12,7 +12,6 @@ namespace DN.WebApi.Host.Controllers.Identity;
 [ApiController]
 [Route("api/[controller]")]
 [ApiVersionNeutral]
-[ApiConventionType(typeof(FSHApiConventions))]
 public sealed class TokensController : ControllerBase
 {
     private readonly ITokenService _tokenService;
@@ -26,6 +25,9 @@ public sealed class TokensController : ControllerBase
     [AllowAnonymous]
     [SwaggerHeader(HeaderConstants.Tenant, "Input your tenant Id to access this API", "", true)]
     [OpenApiOperation("Submit Credentials with Tenant Key to generate valid Access Token.", "")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
+    [ProducesDefaultResponseType(typeof(ErrorResult<string>))]
     public async Task<ActionResult<Result<TokenResponse>>> GetTokenAsync(TokenRequest request)
     {
         var token = await _tokenService.GetTokenAsync(request, GenerateIPAddress());


### PR DESCRIPTION
This is again 2 pr's in concert, this one on the api and another one [on the blazor repo](https://github.com/fullstackhero/blazor-wasm-boilerplate/pull/50).

I found out that the `GetTokenAsync` method sometimes (when you send an empty mail or password) returns a 400 - bad request with a ProblemDetails response (in stead of the default ErrorResult response that is returned by our ExceptionMiddleware). 
Not sure why though as there are no validation attributes on the TokenRequest object... Could it be because the properties on the object are non nullable?

Anyways... simply adding

[ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]

to the method (together with the other 2: 200 and the defaultresponsetype ==> once you add a specific `ProducesResponseType` attribute on a method, the ApiConventions are skipped for that method, so you have to add the other 2 as well).

This is enough to let the client take that into account and even create a nice problemresponse type which we can read out... see the pr on the blazor repo for that ;-)
