### PR TITLE
Put DefaultIdType global using into Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,4 +20,8 @@
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="Properties\stylecop.json" />
         <AdditionalFiles Include="$(MSBuildThisFileDirectory).editorconfig" Link="Properties\.editorconfig" />
     </ItemGroup>
+    <ItemGroup>
+        <!-- Define the global DefaultIdType here. -->
+        <Using Include="System.Guid" Alias="DefaultIdType" />
+    </ItemGroup>
 </Project>

--- a/src/Core/Application/Application.csproj
+++ b/src/Core/Application/Application.csproj
@@ -16,7 +16,4 @@
         <ProjectReference Include="..\Domain\Domain.csproj" />
         <ProjectReference Include="..\Shared\Shared.csproj" />
     </ItemGroup>
-    <ItemGroup>
-            <Compile Include="..\..\GlobalTypeDefs.cs"/>
-    </ItemGroup>
 </Project>

--- a/src/Core/Domain/Domain.csproj
+++ b/src/Core/Domain/Domain.csproj
@@ -10,7 +10,4 @@
     <ItemGroup>
       <ProjectReference Include="..\Shared\Shared.csproj" />
     </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\..\GlobalTypeDefs.cs"/>
-  </ItemGroup>
 </Project>

--- a/src/GlobalTypeDefs.cs
+++ b/src/GlobalTypeDefs.cs
@@ -1,1 +1,0 @@
-﻿global using DefaultIdType = System.Guid;

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -62,7 +62,4 @@
     <ItemGroup>
         <None Update="Catalog\*.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\GlobalTypeDefs.cs"/>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
I first tried putting the GlobalTypeDefs.cs file in directory.build.props... but then it struck me... you can also define global usings in the project file... not even a need for a source file! ;-)

This is a very nice feature of .NET 6...