### PR TITLE
Fix DomainEvents

### DIFF
--- a/src/Core/Domain/Common/Contracts/BaseEntity.cs
+++ b/src/Core/Domain/Common/Contracts/BaseEntity.cs
@@ -8,9 +8,9 @@ public abstract class BaseEntity : BaseEntity<DefaultIdType>
     protected BaseEntity() => Id = NewId.Next().ToGuid();
 }
 
-public abstract class BaseEntity<T> : IEntity<T>
+public abstract class BaseEntity<TId> : IEntity<TId>
 {
-    public T Id { get; protected set; } = default!;
+    public TId Id { get; protected set; } = default!;
 
     [NotMapped]
     public List<DomainEvent> DomainEvents { get; } = new();

--- a/src/Core/Domain/Common/Contracts/BaseEntity.cs
+++ b/src/Core/Domain/Common/Contracts/BaseEntity.cs
@@ -1,4 +1,5 @@
 using MassTransit;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FSH.WebApi.Domain.Common.Contracts;
 
@@ -11,5 +12,6 @@ public abstract class BaseEntity<T> : IEntity<T>
 {
     public T Id { get; protected set; } = default!;
 
-    public List<DomainEvent> DomainEvents = new();
+    [NotMapped]
+    public List<DomainEvent> DomainEvents { get; } = new();
 }

--- a/src/Core/Domain/Common/Contracts/IEntity.cs
+++ b/src/Core/Domain/Common/Contracts/IEntity.cs
@@ -2,6 +2,7 @@
 
 public interface IEntity
 {
+    List<DomainEvent> DomainEvents { get; }
 }
 
 public interface IEntity<T> : IEntity

--- a/src/Core/Domain/Common/Contracts/IEntity.cs
+++ b/src/Core/Domain/Common/Contracts/IEntity.cs
@@ -5,7 +5,7 @@ public interface IEntity
     List<DomainEvent> DomainEvents { get; }
 }
 
-public interface IEntity<T> : IEntity
+public interface IEntity<TId> : IEntity
 {
-    T Id { get; }
+    TId Id { get; }
 }

--- a/src/Infrastructure/Persistence/Context/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/Context/ApplicationDbContext.cs
@@ -54,7 +54,7 @@ public class ApplicationDbContext : BaseDbContext
         }
 
         int results = await base.SaveChangesAsync(cancellationToken);
-        if (_eventService == null) return results;
+
         var entitiesWithEvents = ChangeTracker.Entries<IEntity>()
             .Select(e => e.Entity)
             .Where(e => e.DomainEvents.Count > 0)
@@ -62,11 +62,11 @@ public class ApplicationDbContext : BaseDbContext
 
         foreach (var entity in entitiesWithEvents)
         {
-            var events = entity.DomainEvents.ToArray();
+            var domainEvents = entity.DomainEvents.ToArray();
             entity.DomainEvents.Clear();
-            foreach (var @event in events)
+            foreach (var domainEvent in domainEvents)
             {
-                await _eventService.PublishAsync(@event);
+                await _eventService.PublishAsync(domainEvent);
             }
         }
 

--- a/src/Infrastructure/Persistence/Context/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/Context/ApplicationDbContext.cs
@@ -55,7 +55,7 @@ public class ApplicationDbContext : BaseDbContext
 
         int results = await base.SaveChangesAsync(cancellationToken);
         if (_eventService == null) return results;
-        var entitiesWithEvents = ChangeTracker.Entries<BaseEntity>()
+        var entitiesWithEvents = ChangeTracker.Entries<IEntity>()
             .Select(e => e.Entity)
             .Where(e => e.DomainEvents.Count > 0)
             .ToArray();

--- a/src/Infrastructure/Persistence/Context/BaseDbContext.cs
+++ b/src/Infrastructure/Persistence/Context/BaseDbContext.cs
@@ -157,12 +157,12 @@ public abstract class BaseDbContext : IdentityDbContext<ApplicationUser, Applica
             }
         }
 
-        foreach (var auditEntry in trailEntries.Where(_ => !_.HasTemporaryProperties))
+        foreach (var auditEntry in trailEntries.Where(e => !e.HasTemporaryProperties))
         {
             AuditTrails.Add(auditEntry.ToAuditTrail());
         }
 
-        return trailEntries.Where(_ => _.HasTemporaryProperties).ToList();
+        return trailEntries.Where(e => e.HasTemporaryProperties).ToList();
     }
 
     private Task OnAfterSaveChangesAsync(List<AuditTrail> trailEntries, in CancellationToken cancellationToken = new())


### PR DESCRIPTION
DomainEvents weren't sent anymore due to checking of `ChangeTracker.Entries<BaseEntity>()`, but our entities are now `BaseEntity<TId>`... 

Fixed it by moving the DomainEvents to the IEntity interface and checking for `ChangeTracker.Entries<IEntity>()`.

Had to make DomainEvents a property (fields are not allowed in interfaces) and add the `[NotMapped]` attibute to keep efcore happy :-s

Still not convinced about the design of how domainevents are handled... open for any suggestions!

But at least now it works again ;-)