### PR TITLE
Fix FSHApiConventions

### DIFF
--- a/src/Host/Controllers/Catalog/BrandsController.cs
+++ b/src/Host/Controllers/Catalog/BrandsController.cs
@@ -45,7 +45,7 @@ public class BrandsController : VersionedApiController
     }
 
     [HttpDelete("delete-random")]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Delete))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Search))]
     public Task<string> DeleteRandomAsync()
     {
         return Mediator.Send(new DeleteRandomBrandRequest());

--- a/src/Host/Controllers/FSHApiConvention.cs
+++ b/src/Host/Controllers/FSHApiConvention.cs
@@ -41,10 +41,38 @@ public static class FSHApiConventions
     [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
     [ProducesDefaultResponseType(typeof(ErrorResult))]
     [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Prefix)]
+    public static void Get(
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object id,
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object cancellationtoken)
+    {
+    }
+
+    [ProducesResponseType(200)]
+    [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
+    [ProducesDefaultResponseType(typeof(ErrorResult))]
+    [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Prefix)]
     public static void Post(
         [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
         [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
         object request)
+    {
+    }
+
+    [ProducesResponseType(200)]
+    [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
+    [ProducesDefaultResponseType(typeof(ErrorResult))]
+    [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Prefix)]
+    public static void Post(
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object request,
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object cancellationToken)
     {
     }
 
@@ -99,6 +127,23 @@ public static class FSHApiConventions
     [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
     [ProducesDefaultResponseType(typeof(ErrorResult))]
     [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Prefix)]
+    public static void Update(
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object request,
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object id,
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object cancellationToken)
+    {
+    }
+
+    [ProducesResponseType(200)]
+    [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
+    [ProducesDefaultResponseType(typeof(ErrorResult))]
+    [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Prefix)]
     public static void Put(
         [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
         [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
@@ -113,10 +158,41 @@ public static class FSHApiConventions
     [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
     [ProducesDefaultResponseType(typeof(ErrorResult))]
     [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Prefix)]
+    public static void Put(
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object request,
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object id,
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object cancellationToken)
+    {
+    }
+
+    [ProducesResponseType(200)]
+    [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
+    [ProducesDefaultResponseType(typeof(ErrorResult))]
+    [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Prefix)]
     public static void Delete(
         [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
         [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
         object id)
+    {
+    }
+
+    [ProducesResponseType(200)]
+    [ProducesResponseType(400, Type = typeof(HttpValidationProblemDetails))]
+    [ProducesDefaultResponseType(typeof(ErrorResult))]
+    [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Prefix)]
+    public static void Delete(
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object id,
+        [ApiConventionNameMatch(ApiConventionNameMatchBehavior.Any)]
+        [ApiConventionTypeMatch(ApiConventionTypeMatchBehavior.Any)]
+        object cancellationToken)
     {
     }
 

--- a/src/Host/Controllers/Identity/IdentityController.cs
+++ b/src/Host/Controllers/Identity/IdentityController.cs
@@ -43,14 +43,14 @@ public sealed class IdentityController : VersionNeutralApiController
     [HttpPost("forgot-password")]
     [AllowAnonymous]
     [TenantIdHeader]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Post))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
     public Task<string> ForgotPasswordAsync(ForgotPasswordRequest request)
     {
         return _identityService.ForgotPasswordAsync(request, OriginFromRequest);
     }
 
     [HttpPost("reset-password")]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Post))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
     public Task<string> ResetPasswordAsync(ResetPasswordRequest request)
     {
         return _identityService.ResetPasswordAsync(request);
@@ -69,7 +69,7 @@ public sealed class IdentityController : VersionNeutralApiController
     }
 
     [HttpPut("change-password")]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Put))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
     public Task ChangePasswordAsync(ChangePasswordRequest model)
     {
         return _identityService.ChangePasswordAsync(model, _currentUser.GetUserId().ToString());

--- a/src/Host/Controllers/Identity/UsersController.cs
+++ b/src/Host/Controllers/Identity/UsersController.cs
@@ -38,7 +38,7 @@ public class UsersController : VersionNeutralApiController
     }
 
     [HttpPost("{id}/roles")]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Post))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
     public Task<string> AssignRolesAsync(string id, UserRolesRequest request, CancellationToken cancellationToken)
     {
         return _userService.AssignRolesAsync(id, request, cancellationToken);
@@ -46,7 +46,7 @@ public class UsersController : VersionNeutralApiController
 
     [HttpPost("toggle-status")]
     [MustHavePermission(FSHPermissions.Users.Edit)]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Post))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
     public Task ToggleUserStatusAsync(ToggleUserStatusRequest request, CancellationToken cancellationToken)
     {
         return _userService.ToggleUserStatusAsync(request, cancellationToken);

--- a/src/Host/Controllers/Multitenancy/TenantsController.cs
+++ b/src/Host/Controllers/Multitenancy/TenantsController.cs
@@ -31,7 +31,7 @@ public class TenantsController : VersionNeutralApiController
     [HttpPost("upgrade")]
     [MustHavePermission(FSHRootPermissions.Tenants.UpgradeSubscription)]
     [OpenApiOperation("Upgrade Subscription of Tenant.", "")]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Post))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
     public Task<string> UpgradeSubscriptionAsync(UpgradeSubscriptionRequest request)
     {
         return Mediator.Send(request);
@@ -40,7 +40,7 @@ public class TenantsController : VersionNeutralApiController
     [HttpPost("{tenantId}/deactivate")]
     [MustHavePermission(FSHRootPermissions.Tenants.Update)]
     [OpenApiOperation("Deactivate Tenant.", "")]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Post))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
     public Task<string> DeactivateTenantAsync(string tenantId)
     {
         return Mediator.Send(new DeactivateTenantRequest(tenantId));
@@ -49,7 +49,7 @@ public class TenantsController : VersionNeutralApiController
     [HttpPost("{tenantId}/activate")]
     [MustHavePermission(FSHRootPermissions.Tenants.Update)]
     [OpenApiOperation("Activate Tenant.", "")]
-    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Post))]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
     public Task<string> ActivateTenantAsync(string tenantId)
     {
         return Mediator.Send(new ActivateTenantRequest(tenantId));

--- a/src/Infrastructure/Identity/TokenService.cs
+++ b/src/Infrastructure/Identity/TokenService.cs
@@ -40,6 +40,11 @@ public class TokenService : ITokenService
 
     public async Task<TokenResponse> GetTokenAsync(TokenRequest request, string ipAddress, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(_currentTenant?.Id))
+        {
+            throw new UnauthorizedException(_localizer["tenant.invalid"]);
+        }
+
         var user = await _userManager.FindByEmailAsync(request.Email.Trim().Normalize());
         if (user is null)
         {
@@ -54,11 +59,6 @@ public class TokenService : ITokenService
         if (_mailSettings.EnableVerification && !user.EmailConfirmed)
         {
             throw new UnauthorizedException(_localizer["identity.emailnotconfirmed"]);
-        }
-
-        if (string.IsNullOrWhiteSpace(_currentTenant?.Id))
-        {
-            throw new UnauthorizedException(_localizer["tenant.invalid"]);
         }
 
         if (_currentTenant.Id != MultitenancyConstants.Root.Id)


### PR DESCRIPTION
Some of the api's didn't have the ProducesResponseType attributes anymore due to adding cancellationtokens.
This pr fixes that... also fixes https://github.com/fullstackhero/blazor-wasm-boilerplate/issues/81... will need an fshapi update there though... 