### PR TITLE
fix errors on startup

### DIFF
--- a/src/Core/Domain/Catalog/Product.cs
+++ b/src/Core/Domain/Catalog/Product.cs
@@ -9,7 +9,7 @@ public class Product : AuditableEntity, IAggregateRoot
     public Guid BrandId { get; private set; }
     public virtual Brand Brand { get; private set; } = default!;
 
-    public Product(string name, string? description, decimal rate, in Guid brandId, string? imagePath)
+    public Product(string name, string? description, decimal rate, Guid brandId, string? imagePath)
     {
         Name = name;
         Description = description;

--- a/src/Host/Controllers/Identity/IdentityController.cs
+++ b/src/Host/Controllers/Identity/IdentityController.cs
@@ -27,7 +27,7 @@ public sealed class IdentityController : VersionNeutralApiController
     [HttpGet("confirm-email")]
     [AllowAnonymous]
     [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Search))]
-    public Task<string> ConfirmEmailAsync([FromQuery] string userId, [FromQuery] string code, [FromQuery] string tenant, in CancellationToken cancellationToken)
+    public Task<string> ConfirmEmailAsync([FromQuery] string userId, [FromQuery] string code, [FromQuery] string tenant, CancellationToken cancellationToken)
     {
         return _identityService.ConfirmEmailAsync(userId, code, tenant, cancellationToken);
     }
@@ -63,7 +63,7 @@ public sealed class IdentityController : VersionNeutralApiController
     }
 
     [HttpGet("profile")]
-    public Task<UserDetailsDto> GetProfileDetailsAsync(in CancellationToken cancellationToken)
+    public Task<UserDetailsDto> GetProfileDetailsAsync(CancellationToken cancellationToken)
     {
         return _userService.GetAsync(_currentUser.GetUserId().ToString(), cancellationToken);
     }

--- a/src/Host/Controllers/Identity/RoleClaimsController.cs
+++ b/src/Host/Controllers/Identity/RoleClaimsController.cs
@@ -10,28 +10,28 @@ public class RoleClaimsController : VersionNeutralApiController
 
     [HttpGet]
     [Authorize(Policy = FSHPermissions.RoleClaims.View)]
-    public Task<List<RoleClaimDto>> GetAllAsync(in CancellationToken cancellationToken)
+    public Task<List<RoleClaimDto>> GetAllAsync(CancellationToken cancellationToken)
     {
         return _roleClaimService.GetAllAsync(cancellationToken);
     }
 
     [HttpGet("{roleId}")]
     [Authorize(Policy = FSHPermissions.RoleClaims.View)]
-    public Task<List<RoleClaimDto>> GetAllByRoleIdAsync([FromRoute] string roleId, in CancellationToken cancellationToken)
+    public Task<List<RoleClaimDto>> GetAllByRoleIdAsync([FromRoute] string roleId, CancellationToken cancellationToken)
     {
         return _roleClaimService.GetAllByRoleIdAsync(roleId, cancellationToken);
     }
 
     [HttpPost]
     [Authorize(Policy = FSHPermissions.RoleClaims.Create)]
-    public Task<string> PostAsync(RoleClaimRequest request, in CancellationToken cancellationToken)
+    public Task<string> PostAsync(RoleClaimRequest request, CancellationToken cancellationToken)
     {
         return _roleClaimService.SaveAsync(request, cancellationToken);
     }
 
     [HttpDelete("{id:int}")]
     [Authorize(Policy = FSHPermissions.RoleClaims.Delete)]
-    public Task<string> DeleteAsync(int id, in CancellationToken cancellationToken)
+    public Task<string> DeleteAsync(int id, CancellationToken cancellationToken)
     {
         return _roleClaimService.DeleteAsync(id, cancellationToken);
     }

--- a/src/Host/Controllers/Identity/RolesController.cs
+++ b/src/Host/Controllers/Identity/RolesController.cs
@@ -24,14 +24,14 @@ public class RolesController : VersionNeutralApiController
 
     [HttpGet("{id}/permissions")]
     [MustHavePermission(FSHPermissions.RoleClaims.View)]
-    public Task<RoleDto> GetByIdWithPermissionsAsync(string id, in CancellationToken cancellationToken)
+    public Task<RoleDto> GetByIdWithPermissionsAsync(string id, CancellationToken cancellationToken)
     {
         return _roleService.GetByIdWithPermissionsAsync(id, cancellationToken);
     }
 
     [HttpPut("permissions")]
     [MustHavePermission(FSHPermissions.RoleClaims.Edit)]
-    public Task<string> UpdatePermissionsAsync(UpdatePermissionsRequest request, in CancellationToken cancellationToken)
+    public Task<string> UpdatePermissionsAsync(UpdatePermissionsRequest request, CancellationToken cancellationToken)
     {
         return _roleService.UpdatePermissionsAsync(request, cancellationToken);
     }

--- a/src/Host/Controllers/Identity/TokensController.cs
+++ b/src/Host/Controllers/Identity/TokensController.cs
@@ -6,16 +6,13 @@ public sealed class TokensController : VersionNeutralApiController
 {
     private readonly ITokenService _tokenService;
 
-    public TokensController(ITokenService tokenService)
-    {
-        _tokenService = tokenService;
-    }
+    public TokensController(ITokenService tokenService) => _tokenService = tokenService;
 
     [HttpPost]
     [AllowAnonymous]
     [TenantIdHeader]
     [OpenApiOperation("Submit Credentials with Tenant Id to generate valid Access Token.", "")]
-    public Task<TokenResponse> GetTokenAsync(TokenRequest request, in CancellationToken cancellationToken)
+    public Task<TokenResponse> GetTokenAsync(TokenRequest request, CancellationToken cancellationToken)
     {
         return _tokenService.GetTokenAsync(request, GetIpAddress(), cancellationToken);
     }

--- a/src/Host/Controllers/Identity/UsersController.cs
+++ b/src/Host/Controllers/Identity/UsersController.cs
@@ -11,35 +11,35 @@ public class UsersController : VersionNeutralApiController
 
     [HttpGet]
     [MustHavePermission(FSHPermissions.Users.View)]
-    public Task<List<UserDetailsDto>> GetAllAsync(in CancellationToken cancellationToken)
+    public Task<List<UserDetailsDto>> GetAllAsync(CancellationToken cancellationToken)
     {
         return _userService.GetAllAsync(cancellationToken);
     }
 
     [HttpGet("{id}")]
     [MustHavePermission(FSHPermissions.Users.View)]
-    public Task<UserDetailsDto> GetByIdAsync(string id, in CancellationToken cancellationToken)
+    public Task<UserDetailsDto> GetByIdAsync(string id, CancellationToken cancellationToken)
     {
         return _userService.GetAsync(id, cancellationToken);
     }
 
     [HttpGet("{id}/roles")]
     [MustHavePermission(FSHPermissions.Roles.View)]
-    public Task<List<UserRoleDto>> GetRolesAsync(string id, in CancellationToken cancellationToken)
+    public Task<List<UserRoleDto>> GetRolesAsync(string id, CancellationToken cancellationToken)
     {
         return _userService.GetRolesAsync(id, cancellationToken);
     }
 
     [HttpGet("{id}/permissions")]
     [MustHavePermission(FSHPermissions.RoleClaims.View)]
-    public Task<List<PermissionDto>> GetPermissionsAsync(string id, in CancellationToken cancellationToken)
+    public Task<List<PermissionDto>> GetPermissionsAsync(string id, CancellationToken cancellationToken)
     {
         return _userService.GetPermissionsAsync(id, cancellationToken);
     }
 
     [HttpPost("{id}/roles")]
     [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
-    public Task<string> AssignRolesAsync(string id, UserRolesRequest request, in CancellationToken cancellationToken)
+    public Task<string> AssignRolesAsync(string id, UserRolesRequest request, CancellationToken cancellationToken)
     {
         return _userService.AssignRolesAsync(id, request, cancellationToken);
     }
@@ -47,7 +47,7 @@ public class UsersController : VersionNeutralApiController
     [HttpPost("toggle-status")]
     [MustHavePermission(FSHPermissions.Users.Edit)]
     [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
-    public Task ToggleUserStatusAsync(ToggleUserStatusRequest request, in CancellationToken cancellationToken)
+    public Task ToggleUserStatusAsync(ToggleUserStatusRequest request, CancellationToken cancellationToken)
     {
         return _userService.ToggleUserStatusAsync(request, cancellationToken);
     }


### PR DESCRIPTION
cancellationtokens can't be "in" parameters, also not allowed in entity constructors (otherwise efcore can't create a new entity)