### PR TITLE
Consistent global usings in FSH projects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
+  "files.insertFinalNewline": false,
   "cSpell.words": [
     "Ardalis",
     "cannotbedeleted",

--- a/src/Core/Application/GlobalUsings.cs
+++ b/src/Core/Application/GlobalUsings.cs
@@ -1,0 +1,17 @@
+global using Ardalis.Specification;
+global using FluentValidation;
+global using FSH.WebApi.Application.Common.Events;
+global using FSH.WebApi.Application.Common.Exceptions;
+global using FSH.WebApi.Application.Common.FileStorage;
+global using FSH.WebApi.Application.Common.Interfaces;
+global using FSH.WebApi.Application.Common.Models;
+global using FSH.WebApi.Application.Common.Persistence;
+global using FSH.WebApi.Application.Common.Specification;
+global using FSH.WebApi.Application.Common.Validation;
+global using FSH.WebApi.Domain.Catalog;
+global using FSH.WebApi.Domain.Common;
+global using FSH.WebApi.Domain.Common.Contracts;
+global using FSH.WebApi.Shared.Notifications;
+global using MediatR;
+global using Microsoft.Extensions.Localization;
+global using Microsoft.Extensions.Logging;

--- a/src/Core/Application/Startup.cs
+++ b/src/Core/Application/Startup.cs
@@ -1,20 +1,3 @@
-global using Ardalis.Specification;
-global using FluentValidation;
-global using FSH.WebApi.Application.Common.Events;
-global using FSH.WebApi.Application.Common.Exceptions;
-global using FSH.WebApi.Application.Common.FileStorage;
-global using FSH.WebApi.Application.Common.Interfaces;
-global using FSH.WebApi.Application.Common.Models;
-global using FSH.WebApi.Application.Common.Persistence;
-global using FSH.WebApi.Application.Common.Specification;
-global using FSH.WebApi.Application.Common.Validation;
-global using FSH.WebApi.Domain.Catalog;
-global using FSH.WebApi.Domain.Common;
-global using FSH.WebApi.Domain.Common.Contracts;
-global using FSH.WebApi.Shared.Notifications;
-global using MediatR;
-global using Microsoft.Extensions.Localization;
-global using Microsoft.Extensions.Logging;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Host/GlobalUsings.cs
+++ b/src/Host/GlobalUsings.cs
@@ -1,0 +1,8 @@
+global using FSH.WebApi.Application.Common.Interfaces;
+global using FSH.WebApi.Application.Common.Models;
+global using FSH.WebApi.Infrastructure.Auth.Permissions;
+global using FSH.WebApi.Infrastructure.OpenApi;
+global using FSH.WebApi.Shared.Authorization;
+global using Microsoft.AspNetCore.Authorization;
+global using Microsoft.AspNetCore.Mvc;
+global using NSwag.Annotations;

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -1,11 +1,3 @@
-global using FSH.WebApi.Application.Common.Interfaces;
-global using FSH.WebApi.Application.Common.Models;
-global using FSH.WebApi.Infrastructure.Auth.Permissions;
-global using FSH.WebApi.Infrastructure.OpenApi;
-global using FSH.WebApi.Shared.Authorization;
-global using Microsoft.AspNetCore.Authorization;
-global using Microsoft.AspNetCore.Mvc;
-global using NSwag.Annotations;
 using FluentValidation.AspNetCore;
 using FSH.WebApi.Application;
 using FSH.WebApi.Host.Configurations;


### PR DESCRIPTION
I moved all global usings to ```GlobalUsings.cs``` in each project to be consistent with ```src/Core/Domain``` project.

Moved global usings from ```src/Host/Program.cs``` to ```src/Host/GlobalUsings.cs``` 
Moved global usings from ```src/Core/Application/Startup.cs``` to ```src/Core/Application/GlobalUsings.cs``` 

I think this way will be much cleaner than having them spread out across multiple files.

I saw you disabled final new lines in .editorconfig and vscode settings so i added also
```json
"files.insertFinalNewline": false
```
to ```.vscode/settings.json``` because i had it enabled in my vscode settings and for some reason it was inserting new lines despite trimFinalNewlines was enabled.