### PR TITLE
SpecificationBuilderExtensions: Search All Fields: skip enums

### DIFF
--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -64,7 +64,9 @@ public static class SpecificationBuilderExtensions
             {
                 // search all fields (only first level)
                 foreach (var property in typeof(T).GetProperties()
-                    .Where(prop => Type.GetTypeCode(Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType) != TypeCode.Object))
+                    .Where(prop => (Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType) is { } propertyType
+                        && !propertyType.IsEnum
+                        && Type.GetTypeCode(propertyType) != TypeCode.Object))
                 {
                     var paramExpr = Expression.Parameter(typeof(T));
                     var propertyExpr = Expression.Property(paramExpr, property);


### PR DESCRIPTION
As System.Enum.ToString is not valid in a linq expression (throws InvalidOperationException).