### PR TITLE
Security header and exception middleware: add check if response has started

### DIFF
--- a/src/Infrastructure/Middleware/ErrorResult.cs
+++ b/src/Infrastructure/Middleware/ErrorResult.cs
@@ -2,7 +2,7 @@
 
 public class ErrorResult
 {
-    public List<string>? Messages { get; set; } = new();
+    public List<string> Messages { get; set; } = new();
 
     public string? Source { get; set; }
     public string? Exception { get; set; }

--- a/src/Infrastructure/SecurityHeaders/Startup.cs
+++ b/src/Infrastructure/SecurityHeaders/Startup.cs
@@ -13,34 +13,37 @@ internal static class Startup
         {
             app.Use(async (context, next) =>
             {
-                if (!string.IsNullOrWhiteSpace(settings.XFrameOptions))
+                if (!context.Response.HasStarted)
                 {
-                    context.Response.Headers.Add(HeaderNames.XFRAMEOPTIONS, settings.XFrameOptions);
-                }
+                    if (!string.IsNullOrWhiteSpace(settings.XFrameOptions))
+                    {
+                        context.Response.Headers.Add(HeaderNames.XFRAMEOPTIONS, settings.XFrameOptions);
+                    }
 
-                if (!string.IsNullOrWhiteSpace(settings.XContentTypeOptions))
-                {
-                    context.Response.Headers.Add(HeaderNames.XCONTENTTYPEOPTIONS, settings.XContentTypeOptions);
-                }
+                    if (!string.IsNullOrWhiteSpace(settings.XContentTypeOptions))
+                    {
+                        context.Response.Headers.Add(HeaderNames.XCONTENTTYPEOPTIONS, settings.XContentTypeOptions);
+                    }
 
-                if (!string.IsNullOrWhiteSpace(settings.ReferrerPolicy))
-                {
-                    context.Response.Headers.Add(HeaderNames.REFERRERPOLICY, settings.ReferrerPolicy);
-                }
+                    if (!string.IsNullOrWhiteSpace(settings.ReferrerPolicy))
+                    {
+                        context.Response.Headers.Add(HeaderNames.REFERRERPOLICY, settings.ReferrerPolicy);
+                    }
 
-                if (!string.IsNullOrWhiteSpace(settings.PermissionsPolicy))
-                {
-                    context.Response.Headers.Add(HeaderNames.PERMISSIONSPOLICY, settings.PermissionsPolicy);
-                }
+                    if (!string.IsNullOrWhiteSpace(settings.PermissionsPolicy))
+                    {
+                        context.Response.Headers.Add(HeaderNames.PERMISSIONSPOLICY, settings.PermissionsPolicy);
+                    }
 
-                if (!string.IsNullOrWhiteSpace(settings.SameSite))
-                {
-                    context.Response.Headers.Add(HeaderNames.SAMESITE, settings.SameSite);
-                }
+                    if (!string.IsNullOrWhiteSpace(settings.SameSite))
+                    {
+                        context.Response.Headers.Add(HeaderNames.SAMESITE, settings.SameSite);
+                    }
 
-                if (!string.IsNullOrWhiteSpace(settings.XXSSProtection))
-                {
-                    context.Response.Headers.Add(HeaderNames.XXSSPROTECTION, settings.XXSSProtection);
+                    if (!string.IsNullOrWhiteSpace(settings.XXSSProtection))
+                    {
+                        context.Response.Headers.Add(HeaderNames.XXSSPROTECTION, settings.XXSSProtection);
+                    }
                 }
 
                 await next();


### PR DESCRIPTION
I saw an exception in my logs: 
```
System.InvalidOperationException: Headers are read-only, response has already started.
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpHeaders.ThrowHeadersReadOnlyException()
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseHeaders.Microsoft.AspNetCore.Http.IHeaderDictionary.set_ContentType(StringValues value)
   at Microsoft.AspNetCore.Http.DefaultHttpResponse.set_ContentType(String value)
   at FSH.WebApi.Infrastructure.Middleware.ExceptionMiddleware.InvokeAsync(HttpContext context, RequestDelegate next) in /src/Infrastructure/Middleware/ExceptionMiddleware.cs:line 53
   at Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.<>c__DisplayClass6_1.<<UseMiddlewareInterface>b__1>d.MoveNext()
--- End of stack trace from previous location ---
   at FSH.WebApi.Infrastructure.SecurityHeaders.Startup.<>c__DisplayClass0_0.<<UseSecurityHeaders>b__0>d.MoveNext() in /src/Infrastructure/SecurityHeaders/Startup.cs:line 47
--- End of stack trace from previous location ---
   at FSH.WebApi.Infrastructure.Localization.LocalizationMiddleware.InvokeAsync(HttpContext context, RequestDelegate next) in /src/Infrastructure/Localization/LocalizationMiddleware.cs:line 19
   at Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.<>c__DisplayClass6_1.<<UseMiddlewareInterface>b__1>d.MoveNext()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
```

Apparently we have to check if the response hasn't started yet.
Added this fix, but didn't see the actual exception that lead to this anymore since... gonna keep an eye on it...

I also added the check to the securityheaders middleware as I first thought the problem was there. Only then I realized it's in the actual exception middleware. So the check in the securityheaders middleware might not be necessary, but I doesn't really hurt either.

Speaking about this securityheader middleware... has this ever been tested actually? Because it can never work like it is now implemented. The headers are in a sub-object "headers" under "securityheadersettings" in the config file... while the SecurityHeaderSettings object doesn't have that hierarchy...