### PR TITLE
Add Advanced Filter (Logic and Operators) on search

### DIFF
--- a/src/Core/Application/Common/Models/BaseFilter.cs
+++ b/src/Core/Application/Common/Models/BaseFilter.cs
@@ -11,4 +11,9 @@ public class BaseFilter
     /// Keyword to Search in All the available columns of the Resource.
     /// </summary>
     public string? Keyword { get; set; }
+
+    /// <summary>
+    /// Advanced column filtering with logical operators and query operators is supported.
+    /// </summary>
+    public IEnumerable<Filter>? AdvancedFilter { get; set; }
 }

--- a/src/Core/Application/Common/Models/BaseFilter.cs
+++ b/src/Core/Application/Common/Models/BaseFilter.cs
@@ -15,5 +15,5 @@ public class BaseFilter
     /// <summary>
     /// Advanced column filtering with logical operators and query operators is supported.
     /// </summary>
-    public IEnumerable<Filter>? AdvancedFilter { get; set; }
+    public Filter? AdvancedFilter { get; set; }
 }

--- a/src/Core/Application/Common/Models/Filter.cs
+++ b/src/Core/Application/Common/Models/Filter.cs
@@ -1,0 +1,37 @@
+﻿namespace FSH.WebApi.Application.Common.Models;
+
+public static class FilterOperator
+{
+    public const string EQ = "eq";
+    public const string NEQ = "neq";
+    public const string LT = "lt";
+    public const string LTE = "lte";
+    public const string GT = "gt";
+    public const string GTE = "gte";
+    public const string BETWEEN = "between";
+    public const string STARTWITH = "startswith";
+    public const string ENDWITH = "endswith";
+    public const string CONTAINS = "contains";
+}
+
+public static class FilterLogic
+{
+    public const string AND = "and";
+    public const string OR = "or";
+    public const string XOR = "xor";
+}
+
+public class Filter
+{
+    public string Field { get; set; }
+
+    public string Operator { get; set; }
+
+    public object Value { get; set; }
+
+    public object? ValueAux { get; set; }
+
+    public string Logic { get; set; }
+
+    public IEnumerable<Filter> Filters { get; set; }
+}

--- a/src/Core/Application/Common/Models/Filter.cs
+++ b/src/Core/Application/Common/Models/Filter.cs
@@ -9,8 +9,8 @@ public static class FilterOperator
     public const string GT = "gt";
     public const string GTE = "gte";
     public const string BETWEEN = "between";
-    public const string STARTWITH = "startswith";
-    public const string ENDWITH = "endswith";
+    public const string STARTSWITH = "startswith";
+    public const string ENDSWITH = "endswith";
     public const string CONTAINS = "contains";
 }
 
@@ -23,15 +23,15 @@ public static class FilterLogic
 
 public class Filter
 {
-    public string Field { get; set; }
+    public string Field { get; set; } = default!;
 
-    public string Operator { get; set; }
+    public string Operator { get; set; } = default!;
 
-    public object Value { get; set; }
+    public object Value { get; set; } = default!;
 
     public object? ValueAux { get; set; }
 
-    public string Logic { get; set; }
+    public string Logic { get; set; } = default!;
 
-    public IEnumerable<Filter> Filters { get; set; }
+    public IEnumerable<Filter> Filters { get; set; } = default!;
 }

--- a/src/Core/Application/Common/Models/Filter.cs
+++ b/src/Core/Application/Common/Models/Filter.cs
@@ -8,7 +8,6 @@ public static class FilterOperator
     public const string LTE = "lte";
     public const string GT = "gt";
     public const string GTE = "gte";
-    public const string BETWEEN = "between";
     public const string STARTSWITH = "startswith";
     public const string ENDSWITH = "endswith";
     public const string CONTAINS = "contains";
@@ -28,8 +27,6 @@ public class Filter
     public string Operator { get; set; } = default!;
 
     public object Value { get; set; } = default!;
-
-    public object? ValueAux { get; set; }
 
     public string Logic { get; set; } = default!;
 

--- a/src/Core/Application/Common/Models/Filter.cs
+++ b/src/Core/Application/Common/Models/Filter.cs
@@ -22,13 +22,13 @@ public static class FilterLogic
 
 public class Filter
 {
-    public string Field { get; set; } = default!;
+    public string? Logic { get; set; }
 
-    public string Operator { get; set; } = default!;
+    public IEnumerable<Filter>? Filters { get; set; }
 
-    public object Value { get; set; } = default!;
+    public string? Field { get; set; }
 
-    public string Logic { get; set; } = default!;
+    public string? Operator { get; set; }
 
-    public IEnumerable<Filter> Filters { get; set; } = default!;
+    public object? Value { get; set; }
 }

--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -52,12 +52,7 @@ public static class SpecificationBuilderExtensions
                 foreach (string field in search.Fields)
                 {
                     var paramExpr = Expression.Parameter(typeof(T));
-
-                    Expression propertyExpr = paramExpr;
-                    foreach (string member in field.Split('.'))
-                    {
-                        propertyExpr = Expression.PropertyOrField(propertyExpr, member);
-                    }
+                    MemberExpression propertyExpr = GetMemberExpression(field, paramExpr);
 
                     specificationBuilder.AddSearchPropertyByKeyword(propertyExpr, paramExpr, search.Keyword);
                 }

--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -87,9 +87,9 @@ public static class SpecificationBuilderExtensions
         return (MemberExpression)mapProperty;
     }
 
-    private static BinaryExpression GetBinaryExpression(MemberExpression memberExpression, ConstantExpression constantExpression, ConstantExpression constantExpressionAux, Filter filter)
+    private static BinaryExpression GetBinaryExpression(MemberExpression memberExpression, ConstantExpression constantExpression, ConstantExpression constantExpressionAux, string filterOperator)
     {
-        return filter.Operator switch
+        return filterOperator switch
         {
             FilterOperator.EQ => Expression.Equal(memberExpression, constantExpression),
             FilterOperator.NEQ => Expression.NotEqual(memberExpression, constantExpression),
@@ -98,7 +98,7 @@ public static class SpecificationBuilderExtensions
             FilterOperator.GT => Expression.GreaterThan(memberExpression, constantExpression),
             FilterOperator.GTE => Expression.GreaterThanOrEqual(memberExpression, constantExpression),
             FilterOperator.BETWEEN => Expression.AndAlso(Expression.GreaterThanOrEqual(memberExpression, constantExpression), Expression.LessThanOrEqual(memberExpression, constantExpressionAux)),
-            _ => throw new ArgumentException("operatorSearch is not valid.", nameof(filter.Operator)),
+            _ => throw new ArgumentException("operatorSearch is not valid.", nameof(filterOperator)),
         };
     }
 
@@ -110,7 +110,7 @@ public static class SpecificationBuilderExtensions
 
         (ConstantExpression value, ConstantExpression valueAx) = GetConstantExpressionFromFilter(mapProperty, filter);
 
-        var bExpresion = GetBinaryExpression(mapProperty, value, valueAx, filter);
+        var bExpresion = GetBinaryExpression(mapProperty, value, valueAx, filter.Operator);
         if (filter.Filters.Any())
         {
             bExpresion = AddFilters(filter.Filters, parameter, bExpresion);

--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -239,8 +239,8 @@ public static class SpecificationBuilderExtensions
 
         string searchTerm = operatorSearch switch
         {
-            FilterOperator.ENDWITH => $"{keyword}%",
-            FilterOperator.STARTWITH => $"%{keyword}",
+            FilterOperator.STARTWITH => $"{keyword}%",
+            FilterOperator.ENDWITH => $"%{keyword}",
             FilterOperator.CONTAINS => $"%{keyword}%",
             _ => throw new ArgumentException("operatorSearch is not valid.", nameof(operatorSearch))
         };

--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -87,6 +87,8 @@ public static class SpecificationBuilderExtensions
         return (MemberExpression)propertyExpression;
     }
 
+    private static string GetStringFromJsonElement(object value) => ((JsonElement)value).GetString()!;
+
     private static Expression CreateFilterExpression(MemberExpression memberExpression, ConstantExpression constantExpression, string filterOperator)
     {
         return filterOperator switch
@@ -103,8 +105,6 @@ public static class SpecificationBuilderExtensions
             _ => throw new CustomException("Filter Operator is not valid."),
         };
     }
-
-    private static string GetStringFromJsonElement(object value) => ((JsonElement)value).GetString()!;
 
     private static Expression CreateFilterExpression(string field, string filterOperator, object value, ParameterExpression parameter)
     {

--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -231,9 +231,11 @@ public static class SpecificationBuilderExtensions
 
     private static ConstantExpression GeValuetExpression(
         string field,
-        object value,
+        object? value,
         Type propertyType)
     {
+        if (value == null) return Expression.Constant(null, propertyType);
+
         if (propertyType.IsEnum)
         {
             string? stringEnum = GetStringFromJsonElement(value);
@@ -258,8 +260,6 @@ public static class SpecificationBuilderExtensions
 
             return Expression.Constant(text, propertyType);
         }
-
-        if (value == null) return Expression.Constant(null, propertyType);
 
         return Expression.Constant(Convert.ChangeType(((JsonElement)value).GetRawText(), propertyType), propertyType);
     }

--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -128,7 +128,7 @@ public static class SpecificationBuilderExtensions
         {
             string? stringEnum = GetStringFromJsonElement(filter.Value!);
 
-            if (!Enum.TryParse(mapProperty.Type, stringEnum, true, out object? valueparsed)) throw new CustomException("Value {0} is not valid for {1}");
+            if (!Enum.TryParse(mapProperty.Type, stringEnum, true, out object? valueparsed)) throw new CustomException(string.Format("Value {0} is not valid for {1}", filter.Value, filter.Field));
 
             cExpresion = Expression.Constant(valueparsed, mapProperty.Type);
         }
@@ -136,7 +136,7 @@ public static class SpecificationBuilderExtensions
         {
             string? stringGuid = GetStringFromJsonElement(filter.Value!);
 
-            if (!Guid.TryParse(stringGuid, out Guid valueparsed)) throw new CustomException("Value {0} is not valid for {1}");
+            if (!Guid.TryParse(stringGuid, out Guid valueparsed)) throw new CustomException(string.Format("Value {0} is not valid for {1}", filter.Value, filter.Field));
 
             cExpresion = Expression.Constant(valueparsed, mapProperty.Type);
         }

--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -81,7 +81,6 @@ public static class SpecificationBuilderExtensions
         return new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
     }
 
-
     private static MemberExpression GetMemberExpression(string propertyName, ParameterExpression parameter)
     {
         Expression mapProperty = parameter;
@@ -95,7 +94,6 @@ public static class SpecificationBuilderExtensions
 
     private static BinaryExpression GetBinaryExpression(MemberExpression memberExpression, ConstantExpression constantExpression, ConstantExpression constantExpressionAux, Filter filter)
     {
-
         return filter.Operator switch
         {
             FilterOperator.EQ => Expression.Equal(memberExpression, constantExpression),
@@ -113,7 +111,6 @@ public static class SpecificationBuilderExtensions
 
     private static BinaryExpression GetBinaryExpressionFromFilter(Filter filter, ParameterExpression parameter)
     {
-
         MemberExpression mapProperty = GetMemberExpression(filter.Field, parameter);
 
         (ConstantExpression value, ConstantExpression valueAx) = GetConstantExpressionFromFilter(mapProperty, filter);
@@ -126,7 +123,8 @@ public static class SpecificationBuilderExtensions
 
         return bExpresion;
     }
-    private static (ConstantExpression CExpresion, ConstantExpression CExpresionAux) GetConstantExpressionFromFilter(MemberExpression mapProperty, Filter filter)
+
+    private static (ConstantExpression cExpresion, ConstantExpression cExpresionAux) GetConstantExpressionFromFilter(MemberExpression mapProperty, Filter filter)
     {
         ConstantExpression cExpresionAux = default!;
 
@@ -186,7 +184,6 @@ public static class SpecificationBuilderExtensions
             {
                 bResult = bExpresionFilter;
             }
-
         }
 
         return bResult;
@@ -200,15 +197,14 @@ public static class SpecificationBuilderExtensions
         {
             List<string> operatorsSearch = new List<string>
             {
-                FilterOperator.STARTWITH,
-                FilterOperator.ENDWITH,
+                FilterOperator.STARTSWITH,
+                FilterOperator.ENDSWITH,
                 FilterOperator.CONTAINS
             };
 
             // search seleted fields (can contain deeper nested fields)
             foreach (Filter filter in filters)
             {
-
                 var parameter = Expression.Parameter(typeof(T));
 
                 // TODO: Add support for nested filter: like
@@ -222,13 +218,11 @@ public static class SpecificationBuilderExtensions
 
                 ((List<WhereExpressionInfo<T>>)specificationBuilder.Specification.WhereExpressions)
                     .Add(new WhereExpressionInfo<T>(Expression.Lambda<Func<T, bool>>(binaryExpresioFilter, parameter)));
-
             }
         }
 
         return new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
     }
-
 
     private static void AddSearchPropertyByKeyword<T>(this ISpecificationBuilder<T> specificationBuilder, Expression propertyExpr, ParameterExpression paramExpr, string keyword, string operatorSearch = FilterOperator.CONTAINS)
     {
@@ -239,8 +233,8 @@ public static class SpecificationBuilderExtensions
 
         string searchTerm = operatorSearch switch
         {
-            FilterOperator.STARTWITH => $"{keyword}%",
-            FilterOperator.ENDWITH => $"%{keyword}",
+            FilterOperator.STARTSWITH => $"{keyword}%",
+            FilterOperator.ENDSWITH => $"%{keyword}",
             FilterOperator.CONTAINS => $"%{keyword}%",
             _ => throw new ArgumentException("operatorSearch is not valid.", nameof(operatorSearch))
         };


### PR DESCRIPTION
* Add custom filter (operator and logic)
* Add support nested filter
* Add Support data type (guid, enum)

Example use:

Example 1: {{url}}/v1/brands/search
````

{
  "advancedSearch": {
    "fields": [
    ],
    "keyword": ""
  },
  "keyword": "",
  "advancedFilter": {
    "logic": "or",
    "filters": [
      {"field": "name", "operator": "contains", "value": "sam"},
      {"field": "name", "operator": "eq", "value": "Razor"},
      {"field": "name", "operator": "startswith", "value": "MS"}
    ]
  },
  "pageNumber": 0,
  "pageSize": 100,
  "orderBy": [
      "name Desc"
  ]
}

````

Example 2: {{url}}/v1/brands/search
````

{
  "advancedSearch": {
    "fields": [
    ],
    "keyword": ""
  },
  "keyword": "",
  "advancedFilter": {
    "field": "name",
    "operator": "contains",
    "value": "sam"
  },
  "pageNumber": 0,
  "pageSize": 100,
  "orderBy": [
      "name Desc"
  ]
}

````