### PR TITLE
Add HangfireMediatorBridge and use it in generate- and delete-randombrandrequest

### DIFF
--- a/src/Core/Application/Catalog/Brands/DeleteRandomBrandRequest.cs
+++ b/src/Core/Application/Catalog/Brands/DeleteRandomBrandRequest.cs
@@ -4,6 +4,7 @@ public class DeleteRandomBrandRequest : IRequest<string>
 {
 }
 
+// The request to start the deleterandombrands job (which handler is defined in infrastructure)
 public class DeleteRandomBrands : IRequest
 {
 }
@@ -20,6 +21,7 @@ public class DeleteRandomBrandRequestHandler : IRequestHandler<DeleteRandomBrand
         string jobId = "testje";
 
         // Register as a recurring job running every minute
+        // This is just a test... don't forget to remove the recurring job again from hangfire ;-)
         _jobService.AddOrUpdate(jobId, new DeleteRandomBrands(), "* * * * *");
 
         return Task.FromResult(jobId);

--- a/src/Core/Application/Catalog/Brands/DeleteRandomBrandRequest.cs
+++ b/src/Core/Application/Catalog/Brands/DeleteRandomBrandRequest.cs
@@ -4,6 +4,10 @@ public class DeleteRandomBrandRequest : IRequest<string>
 {
 }
 
+public class DeleteRandomBrands : IRequest
+{
+}
+
 public class DeleteRandomBrandRequestHandler : IRequestHandler<DeleteRandomBrandRequest, string>
 {
     private readonly IJobService _jobService;
@@ -12,7 +16,12 @@ public class DeleteRandomBrandRequestHandler : IRequestHandler<DeleteRandomBrand
 
     public Task<string> Handle(DeleteRandomBrandRequest request, CancellationToken cancellationToken)
     {
-        string jobId = _jobService.Schedule<IBrandGeneratorJob>(x => x.CleanAsync(default), TimeSpan.FromSeconds(5));
+        // string jobId = _jobService.Schedule<IBrandGeneratorJob>(x => x.CleanAsync(default), TimeSpan.FromSeconds(5));
+        string jobId = "testje";
+
+        // Register as a recurring job running every minute
+        _jobService.AddOrUpdate(jobId, new DeleteRandomBrands(), "* * * * *");
+
         return Task.FromResult(jobId);
     }
 }

--- a/src/Core/Application/Catalog/Brands/GenerateRandomBrandRequest.cs
+++ b/src/Core/Application/Catalog/Brands/GenerateRandomBrandRequest.cs
@@ -5,6 +5,13 @@ public class GenerateRandomBrandRequest : IRequest<string>
     public int NSeed { get; set; }
 }
 
+// The request for which the handler runs in hangfire using _jobService.Enqueue
+// The handler is in the infrastructure project, but could as well be here if it doesn't use hangfire-specific stuff.
+public class GenerateRandomBrands : IRequest
+{
+    public int NSeed { get; set; }
+}
+
 public class GenerateRandomBrandRequestHandler : IRequestHandler<GenerateRandomBrandRequest, string>
 {
     private readonly IJobService _jobService;
@@ -13,7 +20,12 @@ public class GenerateRandomBrandRequestHandler : IRequestHandler<GenerateRandomB
 
     public Task<string> Handle(GenerateRandomBrandRequest request, CancellationToken cancellationToken)
     {
-        string jobId = _jobService.Enqueue<IBrandGeneratorJob>(x => x.GenerateAsync(request.NSeed, default));
+        // The classic way
+        // string jobId = _jobService.Enqueue<IBrandGeneratorJob>(x => x.GenerateAsync(request.NSeed, default));
+
+        // The new way
+        string jobId = _jobService.Enqueue(new GenerateRandomBrands { NSeed = request.NSeed });
+
         return Task.FromResult(jobId);
     }
 }

--- a/src/Core/Application/Common/Interfaces/IJobService.cs
+++ b/src/Core/Application/Common/Interfaces/IJobService.cs
@@ -4,35 +4,26 @@ namespace FSH.WebApi.Application.Common.Interfaces;
 
 public interface IJobService : ITransientService
 {
+    string Enqueue(IRequest request);
+    void AddOrUpdate(string recurringJobId, IRequest request, string cronExpression, TimeZoneInfo? timeZone = null, string queue = "default");
+
     string Enqueue(Expression<Action> methodCall);
-
     string Enqueue(Expression<Func<Task>> methodCall);
-
     string Enqueue<T>(Expression<Action<T>> methodCall);
-
     string Enqueue<T>(Expression<Func<T, Task>> methodCall);
 
     string Schedule(Expression<Action> methodCall, TimeSpan delay);
-
     string Schedule(Expression<Func<Task>> methodCall, TimeSpan delay);
-
     string Schedule(Expression<Action> methodCall, DateTimeOffset enqueueAt);
-
     string Schedule(Expression<Func<Task>> methodCall, DateTimeOffset enqueueAt);
-
     string Schedule<T>(Expression<Action<T>> methodCall, TimeSpan delay);
-
     string Schedule<T>(Expression<Func<T, Task>> methodCall, TimeSpan delay);
-
     string Schedule<T>(Expression<Action<T>> methodCall, DateTimeOffset enqueueAt);
-
     string Schedule<T>(Expression<Func<T, Task>> methodCall, DateTimeOffset enqueueAt);
 
     bool Delete(string jobId);
-
     bool Delete(string jobId, string fromState);
 
     bool Requeue(string jobId);
-
     bool Requeue(string jobId, string fromState);
 }

--- a/src/Infrastructure/BackgroundJobs/HangfireMediatorBridge.cs
+++ b/src/Infrastructure/BackgroundJobs/HangfireMediatorBridge.cs
@@ -1,0 +1,39 @@
+﻿using System.ComponentModel;
+using Finbuckle.MultiTenant;
+using FSH.WebApi.Infrastructure.Auth;
+using FSH.WebApi.Infrastructure.Multitenancy;
+using MediatR;
+
+namespace FSH.WebApi.Infrastructure.BackgroundJobs;
+
+internal class HangfireMediatorBridge
+{
+    private readonly IMediator _mediator;
+    private readonly IMultiTenantStore<FSHTenantInfo> _tenantStore;
+    private readonly IMultiTenantContextAccessor _tenantContextAccessor;
+    private readonly ICurrentUserInitializer _currentUserInitializer;
+
+    public HangfireMediatorBridge(IMediator mediator, IMultiTenantStore<FSHTenantInfo> tenantStore, IMultiTenantContextAccessor tenantContextAccessor, ICurrentUserInitializer currentUserInitializer)
+    {
+        _mediator = mediator;
+        _tenantStore = tenantStore;
+        _tenantContextAccessor = tenantContextAccessor;
+        _currentUserInitializer = currentUserInitializer;
+    }
+
+    [DisplayName("{0}")]
+    public async Task Send(string jobName, string tenantId, string userId, IRequest request, CancellationToken ct)
+    {
+        _tenantContextAccessor.MultiTenantContext =
+            await _tenantStore.TryGetAsync(tenantId) is { } tenantInfo
+                ? new MultiTenantContext<FSHTenantInfo>() { TenantInfo = tenantInfo }
+                : throw new InvalidOperationException("Invalid tenant.");
+
+        _currentUserInitializer.SetCurrentUserId(userId);
+
+        await _mediator.Send(request, ct);
+    }
+
+    [DisplayName("{0}")]
+    public Task Send(string jobName, IRequest request, CancellationToken ct) => _mediator.Send(request, ct);
+}

--- a/src/Infrastructure/BackgroundJobs/HangfireMediatorBridge.cs
+++ b/src/Infrastructure/BackgroundJobs/HangfireMediatorBridge.cs
@@ -21,6 +21,17 @@ internal class HangfireMediatorBridge
         _currentUserInitializer = currentUserInitializer;
     }
 
+    // This method can be used for "Enqueue"-ing or "Schedule"-ing jobs. In this case the
+    // current tenant and current user are handled by FSHJobFilter and FSHJobActivator
+    [DisplayName("{0}")]
+    public Task Send(string jobName, IRequest request, CancellationToken ct) => _mediator.Send(request, ct);
+
+    // This method has to be used for recurring jobs (with "AddOrUpdate") because in that case
+    // FSHJobFilter.OnCreating is called outside of the context of a request (there's no HttpContext available)
+    // so you have to supply tenantId and userId which are then resolved again here (inside the hangfire job)
+    // before actually sending the request.
+    // See also https://github.com/HangfireIO/Hangfire/pull/570 and https://github.com/HangfireIO/Hangfire/pull/1420
+    // which would add a "parameters" argument to AddOrUpdate so FSHJobActivator could also be used for this in stead of this "hack".
     [DisplayName("{0}")]
     public async Task Send(string jobName, string tenantId, string userId, IRequest request, CancellationToken ct)
     {
@@ -33,7 +44,4 @@ internal class HangfireMediatorBridge
 
         await _mediator.Send(request, ct);
     }
-
-    [DisplayName("{0}")]
-    public Task Send(string jobName, IRequest request, CancellationToken ct) => _mediator.Send(request, ct);
 }

--- a/src/Infrastructure/BackgroundJobs/HangfireService.cs
+++ b/src/Infrastructure/BackgroundJobs/HangfireService.cs
@@ -1,11 +1,32 @@
 using System.Linq.Expressions;
+using System.Text.Json;
 using FSH.WebApi.Application.Common.Interfaces;
+using FSH.WebApi.Infrastructure.Multitenancy;
 using Hangfire;
+using MediatR;
 
 namespace FSH.WebApi.Infrastructure.BackgroundJobs;
 
 public class HangfireService : IJobService
 {
+    private readonly FSHTenantInfo _currentTenant;
+    private readonly ICurrentUser _currentUser;
+
+    public HangfireService(FSHTenantInfo currentTenant, ICurrentUser currentUser) =>
+        (_currentTenant, _currentUser) = (currentTenant, currentUser);
+
+    public string Enqueue(IRequest request) =>
+        BackgroundJob.Enqueue<HangfireMediatorBridge>(bridge => bridge.Send(GetDisplayName(request), request, default));
+    public void AddOrUpdate(string recurringJobId, IRequest request, string cronExpression, TimeZoneInfo? timeZone = null, string queue = "default") =>
+        RecurringJob.AddOrUpdate<HangfireMediatorBridge>(
+            recurringJobId,
+            bridge => bridge.Send(GetDisplayName(request), _currentTenant.Id, _currentUser.GetUserId().ToString(), request, default),
+            cronExpression,
+            timeZone,
+            queue);
+
+    private static string GetDisplayName(IRequest request) => $"{request.GetType().Name} {JsonSerializer.Serialize(request, request.GetType())}";
+
     public bool Delete(string jobId) =>
         BackgroundJob.Delete(jobId);
 

--- a/src/Infrastructure/BackgroundJobs/Startup.cs
+++ b/src/Infrastructure/BackgroundJobs/Startup.cs
@@ -9,6 +9,7 @@ using HangfireBasicAuthenticationFilter;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Serilog;
 
 namespace FSH.WebApi.Infrastructure.BackgroundJobs;
@@ -36,7 +37,8 @@ internal static class Startup
             .UseDatabase(storageSettings.StorageProvider, storageSettings.ConnectionString, config)
             .UseFilter(new FSHJobFilter(provider))
             .UseFilter(new LogJobFilter())
-            .UseConsole());
+            .UseConsole()
+            .UseSerializerSettings(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All })); // necessary for MediatorHangfireBridge
 
         return services;
     }

--- a/src/Infrastructure/Catalog/CleanRandomBrandsHandler.cs
+++ b/src/Infrastructure/Catalog/CleanRandomBrandsHandler.cs
@@ -1,0 +1,43 @@
+﻿using FSH.WebApi.Application.Catalog.Brands;
+using FSH.WebApi.Application.Common.Persistence;
+using FSH.WebApi.Domain.Catalog;
+using Hangfire.Server;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace FSH.WebApi.Infrastructure.Catalog;
+
+public class CleanRandomBrandsHandler : IRequestHandler<DeleteRandomBrands>
+{
+    private readonly ILogger<CleanRandomBrandsHandler> _logger;
+
+    public CleanRandomBrandsHandler(ILogger<CleanRandomBrandsHandler> logger, ISender mediator, IReadRepository<Brand> repository, PerformingContext performingContext)
+    {
+        _logger = logger;
+        _mediator = mediator;
+        _repository = repository;
+        _performingContext = performingContext;
+    }
+
+    private readonly ISender _mediator;
+    private readonly IReadRepository<Brand> _repository;
+    private readonly PerformingContext _performingContext;
+
+    public async Task<Unit> Handle(DeleteRandomBrands request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Initializing Job with Id: {jobId}", _performingContext.BackgroundJob.Id);
+
+        var items = await _repository.ListAsync(new RandomBrandsSpec(), cancellationToken);
+
+        _logger.LogInformation("Brands Random: {brandsCount} ", items.Count.ToString());
+
+        foreach (var item in items)
+        {
+            await _mediator.Send(new DeleteBrandRequest(item.Id), cancellationToken);
+        }
+
+        _logger.LogInformation("All random brands deleted.");
+
+        return Unit.Value;
+    }
+}

--- a/src/Infrastructure/Catalog/GenerateRandomBrandsHandler.cs
+++ b/src/Infrastructure/Catalog/GenerateRandomBrandsHandler.cs
@@ -1,0 +1,70 @@
+﻿using FSH.WebApi.Application.Catalog.Brands;
+using FSH.WebApi.Application.Common.Interfaces;
+using FSH.WebApi.Shared.Notifications;
+using Hangfire.Console.Extensions;
+using Hangfire.Console.Progress;
+using Hangfire.Server;
+using MediatR;
+
+namespace FSH.WebApi.Infrastructure.Catalog;
+
+public class GenerateRandomBrandsHandler : IRequestHandler<GenerateRandomBrands>
+{
+    private readonly ISender _mediator;
+    private readonly IProgressBarFactory _progressBar;
+    private readonly PerformingContext _performingContext;
+    private readonly INotificationSender _notifications;
+    private readonly ICurrentUser _currentUser;
+    private readonly IProgressBar _progress;
+
+    public GenerateRandomBrandsHandler(
+        ISender mediator,
+        IProgressBarFactory progressBar,
+        PerformingContext performingContext,
+        INotificationSender notifications,
+        ICurrentUser currentUser)
+    {
+        _mediator = mediator;
+        _progressBar = progressBar;
+        _performingContext = performingContext;
+        _notifications = notifications;
+        _currentUser = currentUser;
+        _progress = _progressBar.Create();
+    }
+
+    public async Task<Unit> Handle(GenerateRandomBrands request, CancellationToken cancellationToken)
+    {
+        await NotifyAsync("Your job processing has started", 0, cancellationToken);
+
+        foreach (int index in Enumerable.Range(1, request.NSeed))
+        {
+            await _mediator.Send(
+                new CreateBrandRequest
+                {
+                    Name = $"Brand Random - {Guid.NewGuid()}",
+                    Description = "Funny description"
+                },
+                cancellationToken);
+
+            await NotifyAsync("Progress: ", request.NSeed > 0 ? (index * 100 / request.NSeed) : 0, cancellationToken);
+        }
+
+        await NotifyAsync("Job successfully completed", 0, cancellationToken);
+
+        return Unit.Value;
+    }
+
+    private async Task NotifyAsync(string message, int progress, CancellationToken cancellationToken)
+    {
+        _progress.SetValue(progress);
+        await _notifications.SendToUserAsync(
+            new JobNotification()
+            {
+                JobId = _performingContext.BackgroundJob.Id,
+                Message = message,
+                Progress = progress
+            },
+            _currentUser.GetUserId().ToString(),
+            cancellationToken);
+    }
+}


### PR DESCRIPTION
This is more like a POC for using mediator and hangfire together.

Not sure if the generate- and delete-brandrequest are a good example for this, but it was the fastest I could come up with... just transformed the BrandGeneratorJob into 2 different IRequests (which live in application) and their respective handlers (which live in infrastructure... but might as well live in application if they don't use hanfire specific stuff.

This is just a start... we can probably abstract the other important hangfire stuff away (like what's available on PerformingContext, and that IProgressBarFactory) so that can maybe also be used from application.

It also works for recurring jobs. As an example, I've changed the DeleteRandomBrands to actually add a recurring job that runs every minute. Just as an example... you have to remove the recurringjob manually again after testing ;-)