### PR TITLE
Added conditional logging to Caching/Startup.cs

### DIFF
--- a/src/Infrastructure/Caching/Startup.cs
+++ b/src/Infrastructure/Caching/Startup.cs
@@ -1,11 +1,13 @@
-﻿using FSH.WebApi.Application.Common.Caching;
+using FSH.WebApi.Application.Common.Caching;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Serilog;
 
 namespace FSH.WebApi.Infrastructure.Caching;
 
 internal static class Startup
 {
+    private static readonly ILogger Logger = Log.ForContext(typeof(Startup));
     internal static IServiceCollection AddCaching(this IServiceCollection services, IConfiguration config)
     {
         var settings = config.GetSection(nameof(CacheSettings)).Get<CacheSettings>();
@@ -17,15 +19,17 @@ internal static class Startup
                 services.AddStackExchangeRedisCache(options =>
                 {
                     options.Configuration = settings.RedisURL;
-                    options.ConfigurationOptions = new StackExchange.Redis.ConfigurationOptions()
+                    options.ConfigurationOptions = new ConfigurationOptions()
                     {
                         AbortOnConnectFail = true,
                         EndPoints = { settings.RedisURL }
                     };
+                    Logger.Information($"Using Redis distributed cache : {settings.RedisURL} , if using redis stack, default management UI is http://localhost:8001");
                 });
             }
             else
             {
+                Logger.Information("Using distributed memory cache");
                 services.AddDistributedMemoryCache();
             }
 
@@ -33,6 +37,7 @@ internal static class Startup
         }
         else
         {
+            Logger.Information("Using local memory cache");
             services.AddMemoryCache();
             services.AddTransient<ICacheService, LocalCacheService>();
         }


### PR DESCRIPTION
Splitting the redis host and port could make logging the redis stack browser adress easier, defaulted to localhost for the moment