### PR TITLE
Use OptionsBuilder to add cleaner configuration validation

### DIFF
--- a/src/Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
+++ b/src/Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
@@ -1,0 +1,73 @@
+﻿using System.Security.Claims;
+using System.Text;
+using FSH.WebApi.Application.Common.Exceptions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FSH.WebApi.Infrastructure.Auth.Jwt;
+
+public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions>
+{
+    private readonly JwtSettings _jwtSettings;
+
+    public ConfigureJwtBearerOptions(IOptions<JwtSettings> jwtSettings)
+    {
+        _jwtSettings = jwtSettings.Value;
+    }
+
+    public void Configure(JwtBearerOptions options)
+    {
+        Configure(string.Empty, options);
+    }
+
+    public void Configure(string name, JwtBearerOptions options)
+    {
+        if (name != JwtBearerDefaults.AuthenticationScheme)
+        {
+            return;
+        }
+
+        byte[] key = Encoding.ASCII.GetBytes(_jwtSettings.Key!);
+
+        options.RequireHttpsMetadata = false;
+        options.SaveToken = true;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(key),
+            ValidateIssuer = false,
+            ValidateLifetime = true,
+            ValidateAudience = false,
+            RoleClaimType = ClaimTypes.Role,
+            ClockSkew = TimeSpan.Zero
+        };
+        options.Events = new JwtBearerEvents
+        {
+            OnChallenge = context =>
+            {
+                context.HandleResponse();
+                if (!context.Response.HasStarted)
+                {
+                    throw new UnauthorizedException("Authentication Failed.");
+                }
+
+                return Task.CompletedTask;
+            },
+            OnForbidden = _ => throw new ForbiddenException("You are not authorized to access this resource."),
+            OnMessageReceived = context =>
+            {
+                var accessToken = context.Request.Query["access_token"];
+
+                if (!string.IsNullOrEmpty(accessToken) &&
+                    context.HttpContext.Request.Path.StartsWithSegments("/notifications"))
+                {
+                    // Read the token out of the query string
+                    context.Token = accessToken;
+                }
+
+                return Task.CompletedTask;
+            }
+        };
+    }
+}

--- a/src/Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
+++ b/src/Infrastructure/Auth/Jwt/ConfigureJwtBearerOptions.cs
@@ -28,7 +28,7 @@ public class ConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions
             return;
         }
 
-        byte[] key = Encoding.ASCII.GetBytes(_jwtSettings.Key!);
+        byte[] key = Encoding.ASCII.GetBytes(_jwtSettings.Key);
 
         options.RequireHttpsMetadata = false;
         options.SaveToken = true;

--- a/src/Infrastructure/Auth/Jwt/JwtSettings.cs
+++ b/src/Infrastructure/Auth/Jwt/JwtSettings.cs
@@ -1,10 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace FSH.WebApi.Infrastructure.Auth.Jwt;
 
-public class JwtSettings
+public class JwtSettings : IValidatableObject
 {
-    public string? Key { get; set; }
+    public string Key { get; set; } = string.Empty;
 
     public int TokenExpirationInMinutes { get; set; }
 
     public int RefreshTokenExpirationInDays { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrEmpty(Key))
+        {
+            yield return new ValidationResult("No Key defined in JwtSettings config", new[] { nameof(Key) });
+        }
+    }
 }

--- a/src/Infrastructure/Auth/Jwt/Startup.cs
+++ b/src/Infrastructure/Auth/Jwt/Startup.cs
@@ -11,7 +11,7 @@ internal static class Startup
     {
         services.AddOptions<JwtSettings>()
             .BindConfiguration($"SecuritySettings:{nameof(JwtSettings)}")
-            .Validate(jwtSettings => !string.IsNullOrEmpty(jwtSettings.Key), "No Key defined in JwtSettings config")
+            .ValidateDataAnnotations()
             .ValidateOnStart();
 
         services.AddSingleton<IConfigureOptions<JwtBearerOptions>, ConfigureJwtBearerOptions>();

--- a/src/Infrastructure/Auth/Jwt/Startup.cs
+++ b/src/Infrastructure/Auth/Jwt/Startup.cs
@@ -1,10 +1,7 @@
-﻿using System.Security.Claims;
-using System.Text;
-using FSH.WebApi.Application.Common.Exceptions;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.Options;
 
 namespace FSH.WebApi.Infrastructure.Auth.Jwt;
 
@@ -12,11 +9,12 @@ internal static class Startup
 {
     internal static IServiceCollection AddJwtAuth(this IServiceCollection services, IConfiguration config)
     {
-        services.Configure<JwtSettings>(config.GetSection($"SecuritySettings:{nameof(JwtSettings)}"));
-        var jwtSettings = config.GetSection($"SecuritySettings:{nameof(JwtSettings)}").Get<JwtSettings>();
-        if (string.IsNullOrEmpty(jwtSettings.Key))
-            throw new InvalidOperationException("No Key defined in JwtSettings config.");
-        byte[] key = Encoding.ASCII.GetBytes(jwtSettings.Key);
+        services.AddOptions<JwtSettings>()
+            .BindConfiguration($"SecuritySettings:{nameof(JwtSettings)}")
+            .Validate(jwtSettings => !string.IsNullOrEmpty(jwtSettings.Key), "No Key defined in JwtSettings config")
+            .ValidateOnStart();
+
+        services.AddSingleton<IConfigureOptions<JwtBearerOptions>, ConfigureJwtBearerOptions>();
 
         return services
             .AddAuthentication(authentication =>
@@ -24,48 +22,7 @@ internal static class Startup
                 authentication.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
                 authentication.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
             })
-            .AddJwtBearer(bearer =>
-            {
-                bearer.RequireHttpsMetadata = false;
-                bearer.SaveToken = true;
-                bearer.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(key),
-                    ValidateIssuer = false,
-                    ValidateLifetime = true,
-                    ValidateAudience = false,
-                    RoleClaimType = ClaimTypes.Role,
-                    ClockSkew = TimeSpan.Zero
-                };
-                bearer.Events = new JwtBearerEvents
-                {
-                    OnChallenge = context =>
-                    {
-                        context.HandleResponse();
-                        if (!context.Response.HasStarted)
-                        {
-                            throw new UnauthorizedException("Authentication Failed.");
-                        }
-
-                        return Task.CompletedTask;
-                    },
-                    OnForbidden = _ => throw new ForbiddenException("You are not authorized to access this resource."),
-                    OnMessageReceived = context =>
-                    {
-                        var accessToken = context.Request.Query["access_token"];
-
-                        if (!string.IsNullOrEmpty(accessToken) &&
-                            context.HttpContext.Request.Path.StartsWithSegments("/notifications"))
-                        {
-                            // Read the token out of the query string
-                            context.Token = accessToken;
-                        }
-
-                        return Task.CompletedTask;
-                    }
-                };
-            })
+            .AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, null!)
             .Services;
     }
 }

--- a/src/Infrastructure/Identity/TokenService.cs
+++ b/src/Infrastructure/Identity/TokenService.cs
@@ -144,7 +144,7 @@ internal class TokenService : ITokenService
         var tokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key!)),
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key)),
             ValidateIssuer = false,
             ValidateAudience = false,
             RoleClaimType = ClaimTypes.Role,
@@ -166,7 +166,7 @@ internal class TokenService : ITokenService
 
     private SigningCredentials GetSigningCredentials()
     {
-        byte[] secret = Encoding.UTF8.GetBytes(_jwtSettings.Key!);
+        byte[] secret = Encoding.UTF8.GetBytes(_jwtSettings.Key);
         return new SigningCredentials(new SymmetricSecurityKey(secret), SecurityAlgorithms.HmacSha256);
     }
 }

--- a/src/Infrastructure/Identity/TokenService.cs
+++ b/src/Infrastructure/Identity/TokenService.cs
@@ -141,15 +141,10 @@ internal class TokenService : ITokenService
 
     private ClaimsPrincipal GetPrincipalFromExpiredToken(string token)
     {
-        if (string.IsNullOrEmpty(_jwtSettings.Key))
-        {
-            throw new InvalidOperationException("No Key defined in JwtSettings config.");
-        }
-
         var tokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key)),
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key!)),
             ValidateIssuer = false,
             ValidateAudience = false,
             RoleClaimType = ClaimTypes.Role,
@@ -171,12 +166,7 @@ internal class TokenService : ITokenService
 
     private SigningCredentials GetSigningCredentials()
     {
-        if (string.IsNullOrEmpty(_jwtSettings.Key))
-        {
-            throw new InvalidOperationException("No Key defined in JwtSettings config.");
-        }
-
-        byte[] secret = Encoding.UTF8.GetBytes(_jwtSettings.Key);
+        byte[] secret = Encoding.UTF8.GetBytes(_jwtSettings.Key!);
         return new SigningCredentials(new SymmetricSecurityKey(secret), SecurityAlgorithms.HmacSha256);
     }
 }

--- a/src/Infrastructure/Multitenancy/Startup.cs
+++ b/src/Infrastructure/Multitenancy/Startup.cs
@@ -20,7 +20,7 @@ internal static class Startup
             {
                 // TODO: We should probably add specific dbprovider/connectionstring setting for the tenantDb with a fallback to the main databasesettings
                 var databaseSettings = p.GetRequiredService<IOptions<DatabaseSettings>>().Value;
-                m.UseDatabase(databaseSettings.DBProvider!, databaseSettings.ConnectionString!);
+                m.UseDatabase(databaseSettings.DBProvider, databaseSettings.ConnectionString);
             })
             .AddMultiTenant<FSHTenantInfo>()
                 .WithClaimStrategy(FSHClaims.Tenant)

--- a/src/Infrastructure/Multitenancy/Startup.cs
+++ b/src/Infrastructure/Multitenancy/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
 namespace FSH.WebApi.Infrastructure.Multitenancy;
@@ -14,15 +15,13 @@ internal static class Startup
 {
     internal static IServiceCollection AddMultitenancy(this IServiceCollection services, IConfiguration config)
     {
-        // TODO: We should probably add specific dbprovider/connectionstring setting for the tenantDb with a fallback to the main databasesettings
-        var databaseSettings = config.GetSection(nameof(DatabaseSettings)).Get<DatabaseSettings>();
-        string? rootConnectionString = databaseSettings.ConnectionString;
-        if (string.IsNullOrEmpty(rootConnectionString)) throw new InvalidOperationException("DB ConnectionString is not configured.");
-        string? dbProvider = databaseSettings.DBProvider;
-        if (string.IsNullOrEmpty(dbProvider)) throw new InvalidOperationException("DB Provider is not configured.");
-
         return services
-            .AddDbContext<TenantDbContext>(m => m.UseDatabase(dbProvider, rootConnectionString))
+            .AddDbContext<TenantDbContext>((p, m) =>
+            {
+                // TODO: We should probably add specific dbprovider/connectionstring setting for the tenantDb with a fallback to the main databasesettings
+                var databaseSettings = p.GetRequiredService<IOptions<DatabaseSettings>>().Value;
+                m.UseDatabase(databaseSettings.DBProvider!, databaseSettings.ConnectionString!);
+            })
             .AddMultiTenant<FSHTenantInfo>()
                 .WithClaimStrategy(FSHClaims.Tenant)
                 .WithHeaderStrategy(MultitenancyConstants.TenantIdName)

--- a/src/Infrastructure/Multitenancy/TenantService.cs
+++ b/src/Infrastructure/Multitenancy/TenantService.cs
@@ -51,7 +51,7 @@ internal class TenantService : ITenantService
 
     public async Task<string> CreateAsync(CreateTenantRequest request, CancellationToken cancellationToken)
     {
-        if (request.ConnectionString?.Trim() == _dbSettings.ConnectionString?.Trim()) request.ConnectionString = string.Empty;
+        if (request.ConnectionString?.Trim() == _dbSettings.ConnectionString.Trim()) request.ConnectionString = string.Empty;
 
         var tenant = new FSHTenantInfo(request.Id, request.Name, request.ConnectionString, request.AdminEmail, request.Issuer);
         await _tenantStore.TryAddAsync(tenant);

--- a/src/Infrastructure/Persistence/Context/BaseDbContext.cs
+++ b/src/Infrastructure/Persistence/Context/BaseDbContext.cs
@@ -58,7 +58,7 @@ public abstract class BaseDbContext : MultiTenantIdentityDbContext<ApplicationUs
 
         if (!string.IsNullOrWhiteSpace(TenantInfo?.ConnectionString))
         {
-            optionsBuilder.UseDatabase(_dbSettings.DBProvider!, TenantInfo.ConnectionString);
+            optionsBuilder.UseDatabase(_dbSettings.DBProvider, TenantInfo.ConnectionString);
         }
     }
 

--- a/src/Infrastructure/Persistence/DatabaseSettings.cs
+++ b/src/Infrastructure/Persistence/DatabaseSettings.cs
@@ -1,7 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace FSH.WebApi.Infrastructure.Persistence;
 
-public class DatabaseSettings
+public class DatabaseSettings : IValidatableObject
 {
-    public string? DBProvider { get; set; }
-    public string? ConnectionString { get; set; }
+    public string DBProvider { get; set; } = string.Empty;
+    public string ConnectionString { get; set; } = string.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrEmpty(DBProvider))
+        {
+            yield return new ValidationResult(
+                $"{nameof(DatabaseSettings)}.{nameof(DBProvider)} is not configured",
+                new[] {nameof(DBProvider)});
+        }
+
+        if (string.IsNullOrEmpty(ConnectionString))
+        {
+            yield return new ValidationResult(
+                $"{nameof(DatabaseSettings)}.{nameof(ConnectionString)} is not configured",
+                new[] {nameof(ConnectionString)});
+        }
+    }
 }

--- a/src/Infrastructure/Persistence/Startup.cs
+++ b/src/Infrastructure/Persistence/Startup.cs
@@ -8,6 +8,7 @@ using FSH.WebApi.Infrastructure.Persistence.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 using Serilog;
 
@@ -19,26 +20,19 @@ internal static class Startup
 
     internal static IServiceCollection AddPersistence(this IServiceCollection services, IConfiguration config)
     {
-        // TODO: there must be a cleaner way to do IOptions validation...
-        var databaseSettings = config.GetSection(nameof(DatabaseSettings)).Get<DatabaseSettings>();
-        string? rootConnectionString = databaseSettings.ConnectionString;
-        if (string.IsNullOrEmpty(rootConnectionString))
-        {
-            throw new InvalidOperationException("DB ConnectionString is not configured.");
-        }
-
-        string? dbProvider = databaseSettings.DBProvider;
-        if (string.IsNullOrEmpty(dbProvider))
-        {
-            throw new InvalidOperationException("DB Provider is not configured.");
-        }
-
-        _logger.Information($"Current DB Provider : {dbProvider}");
+        services.AddOptions<DatabaseSettings>()
+            .BindConfiguration(nameof(DatabaseSettings))
+            .Validate(databaseSettings => !string.IsNullOrEmpty(databaseSettings.DBProvider), $"{nameof(DatabaseSettings)}.{nameof(DatabaseSettings.DBProvider)} is not configured")
+            .Validate(databaseSettings => !string.IsNullOrEmpty(databaseSettings.ConnectionString), $"{nameof(DatabaseSettings)}.{nameof(DatabaseSettings.ConnectionString)} is not configured")
+            .ValidateOnStart();
 
         return services
-            .Configure<DatabaseSettings>(config.GetSection(nameof(DatabaseSettings)))
-
-            .AddDbContext<ApplicationDbContext>(m => m.UseDatabase(dbProvider, rootConnectionString))
+            .AddDbContext<ApplicationDbContext>((p, m) =>
+            {
+                var databaseSettings = p.GetRequiredService<IOptions<DatabaseSettings>>().Value;
+                _logger.Information("Current DB Provider : {dbProvider}", databaseSettings.DBProvider);
+                m.UseDatabase(databaseSettings.DBProvider!, databaseSettings.ConnectionString!);
+            })
 
             .AddTransient<IDatabaseInitializer, DatabaseInitializer>()
             .AddTransient<ApplicationDbInitializer>()

--- a/src/Infrastructure/Persistence/Startup.cs
+++ b/src/Infrastructure/Persistence/Startup.cs
@@ -22,8 +22,7 @@ internal static class Startup
     {
         services.AddOptions<DatabaseSettings>()
             .BindConfiguration(nameof(DatabaseSettings))
-            .Validate(databaseSettings => !string.IsNullOrEmpty(databaseSettings.DBProvider), $"{nameof(DatabaseSettings)}.{nameof(DatabaseSettings.DBProvider)} is not configured")
-            .Validate(databaseSettings => !string.IsNullOrEmpty(databaseSettings.ConnectionString), $"{nameof(DatabaseSettings)}.{nameof(DatabaseSettings.ConnectionString)} is not configured")
+            .ValidateDataAnnotations()
             .ValidateOnStart();
 
         return services
@@ -31,7 +30,7 @@ internal static class Startup
             {
                 var databaseSettings = p.GetRequiredService<IOptions<DatabaseSettings>>().Value;
                 _logger.Information("Current DB Provider : {dbProvider}", databaseSettings.DBProvider);
-                m.UseDatabase(databaseSettings.DBProvider!, databaseSettings.ConnectionString!);
+                m.UseDatabase(databaseSettings.DBProvider, databaseSettings.ConnectionString);
             })
 
             .AddTransient<IDatabaseInitializer, DatabaseInitializer>()

--- a/src/Infrastructure/Persistence/Startup.cs
+++ b/src/Infrastructure/Persistence/Startup.cs
@@ -22,6 +22,10 @@ internal static class Startup
     {
         services.AddOptions<DatabaseSettings>()
             .BindConfiguration(nameof(DatabaseSettings))
+            .PostConfigure(databaseSettings =>
+            {
+                _logger.Information("Current DB Provider: {dbProvider}", databaseSettings.DBProvider);
+            })
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
@@ -29,7 +33,6 @@ internal static class Startup
             .AddDbContext<ApplicationDbContext>((p, m) =>
             {
                 var databaseSettings = p.GetRequiredService<IOptions<DatabaseSettings>>().Value;
-                _logger.Information("Current DB Provider : {dbProvider}", databaseSettings.DBProvider);
                 m.UseDatabase(databaseSettings.DBProvider, databaseSettings.ConnectionString);
             })
 

--- a/tests/Infrastructure.Test/Validation/DatabaseSettingsValidationTests.cs
+++ b/tests/Infrastructure.Test/Validation/DatabaseSettingsValidationTests.cs
@@ -1,0 +1,80 @@
+﻿using System.ComponentModel.DataAnnotations;
+using FSH.WebApi.Infrastructure.Persistence;
+using Xunit;
+
+namespace Infrastructure.Test;
+
+public class DatabaseSettingsValidationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ValidateShouldReturnResultWhenConnectionStringIsInvalid(string connectionString)
+    {
+        // Arrange
+        var settings = new DatabaseSettings
+        {
+            DBProvider = "dbProvider",
+            ConnectionString = connectionString
+        };
+        var validationContext = new ValidationContext(settings);
+
+        // Act
+        ICollection<ValidationResult> validationResults = new List<ValidationResult>();
+        Validator.TryValidateObject(settings, validationContext, validationResults);
+
+        // Assert
+        Assert.NotEmpty(validationResults);
+        Assert.Equal(1, validationResults.Count);
+        Assert.Contains(nameof(DatabaseSettings.ConnectionString), validationResults.SelectMany(r => r.MemberNames));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ValidateShouldReturnResultWhenDBProviderIsInvalid(string dbProvider)
+    {
+        // Arrange
+        var settings = new DatabaseSettings
+        {
+            DBProvider = dbProvider,
+            ConnectionString = "connectionString"
+        };
+        var validationContext = new ValidationContext(settings);
+
+        // Act
+        ICollection<ValidationResult> validationResults = new List<ValidationResult>();
+        Validator.TryValidateObject(settings, validationContext, validationResults);
+
+        // Assert
+        Assert.NotEmpty(validationResults);
+        Assert.Equal(1, validationResults.Count);
+        Assert.Contains(nameof(DatabaseSettings.DBProvider), validationResults.SelectMany(r => r.MemberNames));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ValidateShouldReturnAllResultsWhenAllAreInvalid(string invalidValue)
+    {
+        // Arrange
+        var settings = new DatabaseSettings
+        {
+            DBProvider = invalidValue,
+            ConnectionString = invalidValue
+        };
+        var validationContext = new ValidationContext(settings);
+
+        // Act
+        ICollection<ValidationResult> validationResults = new List<ValidationResult>();
+        Validator.TryValidateObject(settings, validationContext, validationResults, true);
+
+        // Assert
+        Assert.NotEmpty(validationResults);
+        Assert.Equal(2, validationResults.Count);
+
+        var invalidMembers = validationResults.SelectMany(r => r.MemberNames).ToList();
+        Assert.Contains(nameof(DatabaseSettings.ConnectionString), invalidMembers);
+        Assert.Contains(nameof(DatabaseSettings.DBProvider), invalidMembers);
+    }
+}


### PR DESCRIPTION
[`ValidateOnStart()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.optionsbuilderextensions.validateonstart?view=dotnet-plat-ext-6.0) was added in .net 6, and it makes it much cleaner for validation of the configurations. 

I saw the TODO, so I went ahead and updated it.

To clean up the JwtBearerOptions validation, I needed to be able to inject the settings for the bearer options configuration. I added `ConfigureJwtBearerOptions` to access the settings, since there isn't a way to access the `IOptions` in `AddJwtBearer`.