### PR TITLE
ApplicationDbRepository.ApplySpecification => only use mapster when no selector is defined

### DIFF
--- a/src/Infrastructure/Persistence/Configuration/SchemaNames.cs
+++ b/src/Infrastructure/Persistence/Configuration/SchemaNames.cs
@@ -3,8 +3,8 @@
 internal static class SchemaNames
 {
     // TODO: figure out how to capitalize these only for Oracle
-    public static string Auditing = "Auditing"; // "AUDITING";
-    public static string Catalog = "Catalog"; // "CATALOG";
-    public static string Identity = "Identity"; // "IDENTITY";
-    public static string MultiTenancy = "MultiTenancy"; // "MULTITENANCY";
+    public static string Auditing = nameof(Auditing); // "AUDITING";
+    public static string Catalog = nameof(Catalog); // "CATALOG";
+    public static string Identity = nameof(Identity); // "IDENTITY";
+    public static string MultiTenancy = nameof(MultiTenancy); // "MULTITENANCY";
 }

--- a/src/Infrastructure/Persistence/Repository/ApplicationDbRepository.cs
+++ b/src/Infrastructure/Persistence/Repository/ApplicationDbRepository.cs
@@ -18,7 +18,10 @@ public class ApplicationDbRepository<T> : RepositoryBase<T>, IReadRepository<T>,
 
     // We override the default behavior when mapping to a dto.
     // We're using Mapster's ProjectToType here to immediately map the result from the database.
+    // This is only done when no Selector is defined, so regular specifications with a selector also still work.
     protected override IQueryable<TResult> ApplySpecification<TResult>(ISpecification<T, TResult> specification) =>
-        ApplySpecification(specification, false)
-            .ProjectToType<TResult>();
+        specification.Selector is not null
+            ? base.ApplySpecification(specification)
+            : ApplySpecification(specification, false)
+                .ProjectToType<TResult>();
 }


### PR DESCRIPTION
this to still support regular specifications with a selector defined.