### PR TITLE
Empty ClientSecret in swagger UI

### DIFF
--- a/src/Infrastructure/OpenApi/Startup.cs
+++ b/src/Infrastructure/OpenApi/Startup.cs
@@ -111,6 +111,7 @@ internal static class Startup
                     {
                         AppName = "Full Stack Hero Api Client",
                         ClientId = config["SecuritySettings:Swagger:OpenIdClientId"],
+                        ClientSecret = string.Empty,
                         UsePkceWithAuthorizationCodeGrant = true,
                         ScopeSeparator = " "
                     };


### PR DESCRIPTION
it's a security issue and not needed anyways (as we're using pkce).