### PR TITLE
Revert "Bump FluentValidation.AspNetCore from 10.4.0 to 11.0.0"

### DIFF
--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>FSH.WebApi.Host</AssemblyName>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="FluentValidation.AspNetCore" Version="11.0.0" />
+        <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
         <PackageReference Include="Hangfire.Console.Extensions.Serilog" Version="1.0.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.4">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Reverts fullstackhero/dotnet-webapi-boilerplate#634