### PR TITLE
Revert "Bump FluentValidation.DependencyInjectionExtensions from 10.4.0 to 11.0.0"

### DIFF
--- a/src/Core/Application/Application.csproj
+++ b/src/Core/Application/Application.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Ardalis.Specification" Version="6.0.1" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.0.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.4.0" />
         <PackageReference Include="Mapster" Version="7.3.0" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />


### PR DESCRIPTION
Reverts fullstackhero/dotnet-webapi-boilerplate#633