### PR TITLE
Fix Dapper

### DIFF
--- a/src/Core/Application/Catalog/Products/GetProductViaDapperRequest.cs
+++ b/src/Core/Application/Catalog/Products/GetProductViaDapperRequest.cs
@@ -20,10 +20,21 @@ public class GetProductViaDapperRequestHandler : IRequestHandler<GetProductViaDa
     public async Task<ProductDto> Handle(GetProductViaDapperRequest request, CancellationToken cancellationToken)
     {
         var product = await _repository.QueryFirstOrDefaultAsync<Product>(
-            $"SELECT * FROM public.\"Products\" WHERE \"Id\"  = '{request.Id}' AND \"Tenant\" = '@tenant'", cancellationToken: cancellationToken);
+            $"SELECT * FROM Catalog.\"Products\" WHERE \"Id\"  = '{request.Id}' AND \"TenantId\" = '@tenant'", cancellationToken: cancellationToken);
 
         _ = product ?? throw new NotFoundException(_t["Product {0} Not Found.", request.Id]);
 
-        return product.Adapt<ProductDto>();
+        // Using mapster here throws a nullreference exception because of the "BrandName" property
+        // in ProductDto and the product not having a Brand assigned.
+        return new ProductDto
+        {
+            Id = product.Id,
+            BrandId = product.BrandId,
+            BrandName = string.Empty,
+            Description = product.Description,
+            ImagePath = product.ImagePath,
+            Name = product.Name,
+            Rate = product.Rate
+        };
     }
 }

--- a/src/Core/Domain/Catalog/Product.cs
+++ b/src/Core/Domain/Catalog/Product.cs
@@ -9,6 +9,12 @@ public class Product : AuditableEntity, IAggregateRoot
     public Guid BrandId { get; private set; }
     public virtual Brand Brand { get; private set; } = default!;
 
+    public Product()
+    {
+        // Only needed for working with dapper (See GetProductViaDapperRequest)
+        // If you're not using dapper it's better to remove this constructor.
+    }
+
     public Product(string name, string? description, decimal rate, Guid brandId, string? imagePath)
     {
         Name = name;

--- a/src/Host/Configurations/database.json
+++ b/src/Host/Configurations/database.json
@@ -1,6 +1,6 @@
 {
   "DatabaseSettings": {
     "DBProvider": "mssql",
-    "ConnectionString": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=rootTenantDb;Integrated Security=True;MultipleActiveResultSets=True"
+    "ConnectionString": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=fullStackHeroDb;Integrated Security=True;MultipleActiveResultSets=True"
   }
 }

--- a/src/Host/Configurations/hangfire.json
+++ b/src/Host/Configurations/hangfire.json
@@ -21,7 +21,7 @@
     },
     "Storage": {
       "StorageProvider": "mssql",
-      "ConnectionString": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=rootTenantDb;Integrated Security=True;MultipleActiveResultSets=True",
+      "ConnectionString": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=fullStackHeroDb;Integrated Security=True;MultipleActiveResultSets=True",
       "Options": {
         "CommandBatchMaxTimeout": "00:05:00",
         "QueuePollInterval": "00:00:01",

--- a/src/Infrastructure/Identity/UserService.Permissions.cs
+++ b/src/Infrastructure/Identity/UserService.Permissions.cs
@@ -11,7 +11,7 @@ internal partial class UserService
     {
         var user = await _userManager.FindByIdAsync(userId);
 
-        _ = user ?? throw new NotFoundException(_t["User Not Found."]);
+        _ = user ?? throw new UnauthorizedException("Authentication Failed.");
 
         var userRoles = await _userManager.GetRolesAsync(user);
         var permissions = new List<string>();

--- a/src/Infrastructure/Persistence/Context/BaseDbContext.cs
+++ b/src/Infrastructure/Persistence/Context/BaseDbContext.cs
@@ -51,10 +51,10 @@ public abstract class BaseDbContext : MultiTenantIdentityDbContext<ApplicationUs
         // If you want to see the sql queries that efcore executes:
 
         // Uncomment the next line to see them in the output window of visual studio
-        // optionsBuilder.LogTo(m => Debug.WriteLine(m), LogLevel.Information);
+        // optionsBuilder.LogTo(m => System.Diagnostics.Debug.WriteLine(m), Microsoft.Extensions.Logging.LogLevel.Information);
 
         // Or uncomment the next line if you want to see them in the console
-        // optionsBuilder.LogTo(Console.WriteLine, LogLevel.Information);
+        // optionsBuilder.LogTo(Console.WriteLine, Microsoft.Extensions.Logging.LogLevel.Information);
 
         if (!string.IsNullOrWhiteSpace(TenantInfo?.ConnectionString))
         {

--- a/src/Infrastructure/Persistence/DatabaseSettings.cs
+++ b/src/Infrastructure/Persistence/DatabaseSettings.cs
@@ -13,14 +13,14 @@ public class DatabaseSettings : IValidatableObject
         {
             yield return new ValidationResult(
                 $"{nameof(DatabaseSettings)}.{nameof(DBProvider)} is not configured",
-                new[] {nameof(DBProvider)});
+                new[] { nameof(DBProvider) });
         }
 
         if (string.IsNullOrEmpty(ConnectionString))
         {
             yield return new ValidationResult(
                 $"{nameof(DatabaseSettings)}.{nameof(ConnectionString)} is not configured",
-                new[] {nameof(ConnectionString)});
+                new[] { nameof(ConnectionString) });
         }
     }
 }

--- a/src/Infrastructure/Persistence/Repository/DapperRepository.cs
+++ b/src/Infrastructure/Persistence/Repository/DapperRepository.cs
@@ -1,7 +1,6 @@
 using System.Data;
 using Dapper;
 using Finbuckle.MultiTenant.EntityFrameworkCore;
-using FSH.WebApi.Application.Common.Exceptions;
 using FSH.WebApi.Application.Common.Persistence;
 using FSH.WebApi.Domain.Common.Contracts;
 using FSH.WebApi.Infrastructure.Persistence.Context;
@@ -22,20 +21,18 @@ public class DapperRepository : IDapperRepository
     public async Task<T?> QueryFirstOrDefaultAsync<T>(string sql, object? param = null, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
     where T : class, IEntity
     {
-        if (!_dbContext.Model.GetMultiTenantEntityTypes().Any(t => t.ClrType == typeof(T)))
+        if (_dbContext.Model.GetMultiTenantEntityTypes().Any(t => t.ClrType == typeof(T)))
         {
             sql = sql.Replace("@tenant", _dbContext.TenantInfo.Id);
         }
 
-        var entity = await _dbContext.Connection.QueryFirstOrDefaultAsync<T>(sql, param, transaction);
-
-        return entity ?? throw new NotFoundException(string.Empty);
+        return await _dbContext.Connection.QueryFirstOrDefaultAsync<T>(sql, param, transaction);
     }
 
     public Task<T> QuerySingleAsync<T>(string sql, object? param = null, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
     where T : class, IEntity
     {
-        if (!_dbContext.Model.GetMultiTenantEntityTypes().Any(t => t.ClrType == typeof(T)))
+        if (_dbContext.Model.GetMultiTenantEntityTypes().Any(t => t.ClrType == typeof(T)))
         {
             sql = sql.Replace("@tenant", _dbContext.TenantInfo.Id);
         }


### PR DESCRIPTION
See also https://github.com/fullstackhero/dotnet-webapi-boilerplate/discussions/678

There were some bugs in DapperRepository and the sql that's executed in GetProductViaDapperRequest.

But next to that, the entities we have now (Product and Brand) are designed to be used with Entity Framework. Trying to use those same entities with Dapper opens a whole can of worms apparently.

I added a default constructor to the Product entity to enable this scenario which kind of breaks the "encapsulation". Another option would be to add a tenantId argument to the existing constructor, but can't really do anything with that, as the TenantId is a shadow property now. It would only be there to satisfy the dapper requirement.

Also using mapster threw a nullreference exception (due to the "BrandName" property in ProductDto and the product not having a Brand assigned), so I changed it to a manual mapping now.

Reflecting on this... I don't think the way we are using dapper here is how it should be used. We have the SQL query in the Application project, which makes it dependent on the database, which is not right.
So I think exposing a generic IDapperRepository is not really the way to do this. If you really need dapper for something, you should implement that in a specific repository (e.g. ProductRepository) in the infrastructure project, and expose an IProductRepository to the application project which uses that e.g. to fetch a product. Then in the implementation you can use dapper any way you want without having to go through the DapperRepository.

Also the fact we're trying to showcase both entity framework and dapper on the same example entities is making things more confusing I think. We should build another example to showcase dapper or use it for something which is not already implemented by using entity framework.