### PR TITLE
Fixed "ambiguous constructors" issue

### DIFF
--- a/src/Infrastructure/OpenApi/Startup.cs
+++ b/src/Infrastructure/OpenApi/Startup.cs
@@ -91,7 +91,14 @@ internal static class Startup
             });
             services.AddScoped<FluentValidationSchemaProcessor>();
         }
+      
+        services.AddScoped<FluentValidationSchemaProcessor>(provider =>
+        {
+            var validationRules = provider.GetService<IEnumerable<FluentValidationRule>>();
+            var loggerFactory = provider.GetService<ILoggerFactory>();
 
+            return new FluentValidationSchemaProcessor(provider, validationRules, loggerFactory);
+        });
         return services;
     }
 


### PR DESCRIPTION
`FluentValidationSchemaProcessor` should be added as a scoped service otherwise this following exception occurs. 
```
System.InvalidOperationException: Unable to activate type 'ZymLabs.NSwag.FluentValidation.FluentValidationSchemaProcessor'. The following constructors are ambiguous:
Void .ctor(System.IServiceProvider, System.Collections.Generic.IEnumerable`1[ZymLabs.NSwag.FluentValidation.FluentValidationRule], Microsoft.Extensions.Logging.ILoggerFactory)
Void .ctor(FluentValidation.IValidatorFactory, System.Collections.Generic.IEnumerable`1[ZymLabs.NSwag.FluentValidation.FluentValidationRule], Microsoft.Extensions.Logging.ILoggerFactory)
```