### PR TITLE
Added Guid schema processor

### DIFF
--- a/src/Infrastructure/OpenApi/Startup.cs
+++ b/src/Infrastructure/OpenApi/Startup.cs
@@ -97,6 +97,8 @@ internal static class Startup
 
                 document.OperationProcessors.Add(new SwaggerHeaderAttributeProcessor());
 
+                document.SchemaProcessors.Add(new SwaggerGuidSchemaProcessor());
+
                 var fluentValidationSchemaProcessor = serviceProvider.CreateScope().ServiceProvider.GetService<FluentValidationSchemaProcessor>();
                 document.SchemaProcessors.Add(fluentValidationSchemaProcessor);
             });

--- a/src/Infrastructure/OpenApi/SwaggerGuidSchemaProcessor.cs
+++ b/src/Infrastructure/OpenApi/SwaggerGuidSchemaProcessor.cs
@@ -1,0 +1,19 @@
+using NJsonSchema;
+using NJsonSchema.Generation;
+
+namespace FSH.WebApi.Infrastructure.OpenApi;
+public class SwaggerGuidSchemaProcessor : ISchemaProcessor
+{
+    public void Process(SchemaProcessorContext context)
+    {
+        var type = context.ContextualType;
+        var schema = context.Schema;
+
+        // Check if the type is a Guid
+        if (type == typeof(Guid))
+        {
+            schema.Type = JsonObjectType.String;
+            schema.Format = "uuid";
+        }
+    }
+}


### PR DESCRIPTION
Added Guid schema processor which replaces the default behavior of displaying GUID values as "string". 

The processor sets the example Guids in Swagger to the format ``"3fa85f64-5717-4562-b3fc-2c963f66afa6"``. This enhances the readability and usability of the Swagger documentation for API consumers.

Example:

Before: ``"data": "string"``  
After: ``"data": "3fa85f64-5717-4562-b3fc-2c963f66afa6"``