### PR TITLE
Feat: Push Notifications

### DIFF
--- a/src/Core/Application/Common/PushNotifications/IPushNotificationServiceFactory.cs
+++ b/src/Core/Application/Common/PushNotifications/IPushNotificationServiceFactory.cs
@@ -1,0 +1,13 @@
+﻿using FSH.WebApi.Application.Multitenancy;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Application.Common.PushNotifications;
+
+public interface IPushNotificationServiceFactory : ITransientService
+{
+    IPushNotificationsService? Create();
+}

--- a/src/Core/Application/Common/PushNotifications/IPushNotificationsService.cs
+++ b/src/Core/Application/Common/PushNotifications/IPushNotificationsService.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Application.Common.PushNotifications;
+
+public interface IPushNotificationsService : ITransientService
+{
+    Task SendTo(string userId, ICollection<Message> message);
+
+    Task SendTo(string userId, string templateName);
+
+    Task SendToAll(ICollection<Message> message);
+
+    Task SendToAll(string templateName);
+
+    Task SendToActiveUsers(ICollection<Message> message);
+
+    Task SendToActiveUsers(string templateName);
+
+    Task SendToInactiveUsers(ICollection<Message> message);
+
+    Task SendToInactiveUsers(string templateName);
+}

--- a/src/Core/Application/Common/PushNotifications/IPushNotificationsTemplateFactory.cs
+++ b/src/Core/Application/Common/PushNotifications/IPushNotificationsTemplateFactory.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Application.Common.PushNotifications;
+
+public interface IPushNotificationsTemplateFactory : ITransientService
+{
+    PushNotificationTemplate Create(string templateName);
+}

--- a/src/Core/Application/Common/PushNotifications/PushNotifiactionProvider.cs
+++ b/src/Core/Application/Common/PushNotifications/PushNotifiactionProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Application.Common.PushNotifications;
+
+public enum PushNotificationsProvider
+{
+    OneSignal = 1
+}

--- a/src/Core/Application/Common/PushNotifications/PushNotificationTemplate.cs
+++ b/src/Core/Application/Common/PushNotifications/PushNotificationTemplate.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Application.Common.PushNotifications;
+
+public sealed record PushNotificationTemplate(string Name, ICollection<Message> Messages);
+public sealed record Message(string Language, string Heading, string Content);

--- a/src/Core/Application/Common/PushNotifications/TenantPushNotificationsSettings.cs
+++ b/src/Core/Application/Common/PushNotifications/TenantPushNotificationsSettings.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Application.Common.PushNotifications;
+
+public sealed record TenantPushNotificationsSettings(
+    PushNotificationsProvider Provider,
+    string AppId,
+    string Name,
+    string AuthKey,
+    string IconUrl);

--- a/src/Core/Application/Identity/Users/IUserService.cs
+++ b/src/Core/Application/Identity/Users/IUserService.cs
@@ -8,7 +8,9 @@ public interface IUserService : ITransientService
     Task<PaginationResponse<UserDetailsDto>> SearchAsync(UserListFilter filter, CancellationToken cancellationToken);
 
     Task<bool> ExistsWithNameAsync(string name);
+
     Task<bool> ExistsWithEmailAsync(string email, string? exceptId = null);
+
     Task<bool> ExistsWithPhoneNumberAsync(string phoneNumber, string? exceptId = null);
 
     Task<List<UserDetailsDto>> GetListAsync(CancellationToken cancellationToken);
@@ -18,22 +20,32 @@ public interface IUserService : ITransientService
     Task<UserDetailsDto> GetAsync(string userId, CancellationToken cancellationToken);
 
     Task<List<UserRoleDto>> GetRolesAsync(string userId, CancellationToken cancellationToken);
+
     Task<string> AssignRolesAsync(string userId, UserRolesRequest request, CancellationToken cancellationToken);
 
     Task<List<string>> GetPermissionsAsync(string userId, CancellationToken cancellationToken);
+
     Task<bool> HasPermissionAsync(string userId, string permission, CancellationToken cancellationToken = default);
+
     Task InvalidatePermissionCacheAsync(string userId, CancellationToken cancellationToken);
 
     Task ToggleStatusAsync(ToggleUserStatusRequest request, CancellationToken cancellationToken);
 
     Task<string> GetOrCreateFromPrincipalAsync(ClaimsPrincipal principal);
+
     Task<string> CreateAsync(CreateUserRequest request, string origin);
+
     Task UpdateAsync(UpdateUserRequest request, string userId);
 
     Task<string> ConfirmEmailAsync(string userId, string code, string tenant, CancellationToken cancellationToken);
+
     Task<string> ConfirmPhoneNumberAsync(string userId, string code);
 
     Task<string> ForgotPasswordAsync(ForgotPasswordRequest request, string origin);
+
     Task<string> ResetPasswordAsync(ResetPasswordRequest request);
+
     Task ChangePasswordAsync(ChangePasswordRequest request, string userId);
+
+    Task<string> SendPushNotificationsAsync(SendPushNotificationsRequest request, CancellationToken cancellationToken);
 }

--- a/src/Core/Application/Identity/Users/SendPushNotificationsRequest.cs
+++ b/src/Core/Application/Identity/Users/SendPushNotificationsRequest.cs
@@ -1,0 +1,25 @@
+﻿using FSH.WebApi.Application.Common.PushNotifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Application.Identity.Users;
+public sealed record SendPushNotificationsRequest
+{
+    public string UserId { get; }
+    public string? PushNotificationsTemplateName { get; }
+    public Message? CustomMessage { get; }
+    public SendPushNotificationsRequest(string userId, string? pushNotificationsTemplateName, Message? customMessage)
+    {
+        if (pushNotificationsTemplateName is not null && customMessage is not null)
+        {
+            throw new ValidationException("Either PushNotificationsTemplateName or CustomMessage must be provided. You can not specify both at the same time.");
+        }
+
+        UserId = userId;
+        PushNotificationsTemplateName = pushNotificationsTemplateName;
+        CustomMessage = customMessage;
+    }
+}

--- a/src/Core/Application/Multitenancy/ITenantService.cs
+++ b/src/Core/Application/Multitenancy/ITenantService.cs
@@ -1,13 +1,24 @@
-﻿namespace FSH.WebApi.Application.Multitenancy;
+﻿using FSH.WebApi.Application.Common.PushNotifications;
+
+namespace FSH.WebApi.Application.Multitenancy;
 
 public interface ITenantService
 {
     Task<List<TenantDto>> GetAllAsync();
+
     Task<bool> ExistsWithIdAsync(string id);
+
     Task<bool> ExistsWithNameAsync(string name);
+
     Task<TenantDto> GetByIdAsync(string id);
+
     Task<string> CreateAsync(CreateTenantRequest request, CancellationToken cancellationToken);
+
     Task<string> ActivateAsync(string id);
+
     Task<string> DeactivateAsync(string id);
+
     Task<string> UpdateSubscription(string id, DateTime extendedExpiryDate);
+
+    Task<string> UpdatePushNotificationInfo(string id, TenantPushNotificationsSettings pushNotificationsSettings);
 }

--- a/src/Core/Application/Multitenancy/UpdatePushNotificationsSettingsRequest.cs
+++ b/src/Core/Application/Multitenancy/UpdatePushNotificationsSettingsRequest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FSH.WebApi.Application.Common.PushNotifications;
+
+namespace FSH.WebApi.Application.Multitenancy;
+public sealed record UpdatePushNotificationsSettingsRequest(string TenantId, TenantPushNotificationsSettings PushNotificationsSettings)
+    : IRequest<string>;
+
+public class UpdatePushNotificationInfoRequestValidator : CustomValidator<UpdatePushNotificationsSettingsRequest>
+{
+    public UpdatePushNotificationInfoRequestValidator() =>
+        RuleFor(t => t.TenantId)
+            .NotEmpty();
+}
+
+public class UpdatePushNotificationInfoRequestHandler : IRequestHandler<UpdatePushNotificationsSettingsRequest, string>
+{
+    private readonly ITenantService _tenantService;
+
+    public UpdatePushNotificationInfoRequestHandler(ITenantService tenantService) => _tenantService = tenantService;
+
+    public Task<string> Handle(UpdatePushNotificationsSettingsRequest request, CancellationToken cancellationToken) =>
+        _tenantService.UpdatePushNotificationInfo(request.TenantId, request.PushNotificationsSettings);
+}

--- a/src/Core/Shared/Authorization/FSHPermissions.cs
+++ b/src/Core/Shared/Authorization/FSHPermissions.cs
@@ -13,6 +13,7 @@ public static class FSHAction
     public const string Generate = nameof(Generate);
     public const string Clean = nameof(Clean);
     public const string UpgradeSubscription = nameof(UpgradeSubscription);
+    public const string SendPushNotifications = nameof(SendPushNotifications);
 }
 
 public static class FSHResource
@@ -40,6 +41,7 @@ public static class FSHPermissions
         new("Update Users", FSHAction.Update, FSHResource.Users),
         new("Delete Users", FSHAction.Delete, FSHResource.Users),
         new("Export Users", FSHAction.Export, FSHResource.Users),
+        new("Send Push Notifications", FSHAction.SendPushNotifications, FSHResource.Users),
         new("View UserRoles", FSHAction.View, FSHResource.UserRoles),
         new("Update UserRoles", FSHAction.Update, FSHResource.UserRoles),
         new("View Roles", FSHAction.View, FSHResource.Roles),

--- a/src/Host/Controllers/Identity/UsersController.cs
+++ b/src/Host/Controllers/Identity/UsersController.cs
@@ -117,5 +117,16 @@ public class UsersController : VersionNeutralApiController
         return _userService.ResetPasswordAsync(request);
     }
 
+    [HttpPost("{id}/send-push-notifications")]
+    [MustHavePermission(FSHAction.SendPushNotifications, FSHResource.Users)]
+    [OpenApiOperation("Send push notifications to a user.", "")]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
+    public async Task<ActionResult> SendPushNotificationsAsync(string id, SendPushNotificationsRequest request, CancellationToken cancellationToken)
+    {
+        return id != request.UserId
+            ? BadRequest()
+            : Ok(await _userService.SendPushNotificationsAsync(request, cancellationToken));
+    }
+
     private string GetOriginFromRequest() => $"{Request.Scheme}://{Request.Host.Value}{Request.PathBase.Value}";
 }

--- a/src/Host/Controllers/Multitenancy/TenantsController.cs
+++ b/src/Host/Controllers/Multitenancy/TenantsController.cs
@@ -56,4 +56,15 @@ public class TenantsController : VersionNeutralApiController
             ? BadRequest()
             : Ok(await Mediator.Send(request));
     }
+
+    [HttpPut("{id}/push-notifications")]
+    [MustHavePermission(FSHAction.Update, FSHResource.Tenants)]
+    [OpenApiOperation("Update a tenant's push notification settings.", "")]
+    [ApiConventionMethod(typeof(FSHApiConventions), nameof(FSHApiConventions.Register))]
+    public async Task<ActionResult<string>> UpdatePushNotificationsSettingsAsync(string id, UpdatePushNotificationsSettingsRequest request)
+    {
+        return id != request.TenantId
+            ? BadRequest()
+            : Ok(await Mediator.Send(request));
+    }
 }

--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -39,6 +39,9 @@
         <None Include="Email Templates\*.html">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Include="PushNotifications Templates\*.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
     <ItemGroup>
         <Content Remove="Logs\*" />

--- a/src/Host/PushNotifications Templates/product-updated.json
+++ b/src/Host/PushNotifications Templates/product-updated.json
@@ -1,0 +1,25 @@
+﻿{
+  "Name": "product-updated",
+  "Messages": [
+    {
+      "Language": "tr",
+      "Heading": "Ürün Güncelleme",
+      "Content": "Sevgili kullanıcı, ürünlerimizden biri güncellendi. Detayları incelemek için lütfen uygulamamızı ziyaret edin."
+    },
+    {
+      "Language": "en",
+      "Heading": "Product Update",
+      "Content": "Dear user, one of our products has been updated. Please visit our app to review the details."
+    },
+    {
+      "Language": "es",
+      "Heading": "Actualización de Producto",
+      "Content": "Estimado usuario, uno de nuestros productos ha sido actualizado. Por favor visite nuestra aplicación para revisar los detalles."
+    },
+    {
+      "Language": "fr",
+      "Heading": "Mise à jour du produit",
+      "Content": "Cher utilisateur, l'un de nos produits a été mis à jour. Veuillez visiter notre application pour consulter les détails."
+    }
+  ]
+}

--- a/src/Infrastructure/Identity/UserService.PushNotifications.cs
+++ b/src/Infrastructure/Identity/UserService.PushNotifications.cs
@@ -1,0 +1,39 @@
+﻿using DocumentFormat.OpenXml.Spreadsheet;
+using FSH.WebApi.Application.Common.Exceptions;
+using FSH.WebApi.Application.Common.Mailing;
+using FSH.WebApi.Application.Identity.Users;
+using FSH.WebApi.Application.Identity.Users.Password;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FSH.WebApi.Infrastructure.Identity;
+
+internal partial class UserService
+{
+    public async Task<string> SendPushNotificationsAsync(SendPushNotificationsRequest request, CancellationToken cancellationToken)
+    {
+        EnsureValidTenant();
+
+        bool userExists = await _userManager.Users.AnyAsync(u => u.Id == request.UserId, cancellationToken);
+        if (!userExists)
+        {
+            throw new NotFoundException(_t["User ({0}) is not found.", request.UserId]);
+        }
+
+        if (_pushNotifications is null)
+        {
+            throw new ForbiddenException(_t["Your tenant's ({0}) push notifications settings has not been configured yet."]);
+        }
+
+        string returnMessage = string.Format(_t["Push notification sent to user {0}."], request.UserId);
+
+        if (!string.IsNullOrWhiteSpace(request.PushNotificationsTemplateName))
+        {
+            await _pushNotifications.SendTo(request.UserId, request.PushNotificationsTemplateName);
+            return returnMessage;
+        }
+
+        await _pushNotifications.SendTo(request.UserId, new[] { request.CustomMessage! });
+        return returnMessage;
+    }
+}

--- a/src/Infrastructure/Identity/UserService.cs
+++ b/src/Infrastructure/Identity/UserService.cs
@@ -8,6 +8,7 @@ using FSH.WebApi.Application.Common.FileStorage;
 using FSH.WebApi.Application.Common.Interfaces;
 using FSH.WebApi.Application.Common.Mailing;
 using FSH.WebApi.Application.Common.Models;
+using FSH.WebApi.Application.Common.PushNotifications;
 using FSH.WebApi.Application.Common.Specification;
 using FSH.WebApi.Application.Identity.Users;
 using FSH.WebApi.Domain.Identity;
@@ -38,6 +39,7 @@ internal partial class UserService : IUserService
     private readonly ICacheService _cache;
     private readonly ICacheKeyService _cacheKeys;
     private readonly ITenantInfo _currentTenant;
+    private readonly IPushNotificationsService? _pushNotifications;
 
     public UserService(
         SignInManager<ApplicationUser> signInManager,
@@ -53,7 +55,8 @@ internal partial class UserService : IUserService
         ICacheService cache,
         ICacheKeyService cacheKeys,
         ITenantInfo currentTenant,
-        IOptions<SecuritySettings> securitySettings)
+        IOptions<SecuritySettings> securitySettings,
+        IPushNotificationServiceFactory pushNotificationsFactory)
     {
         _signInManager = signInManager;
         _userManager = userManager;
@@ -69,6 +72,7 @@ internal partial class UserService : IUserService
         _cacheKeys = cacheKeys;
         _currentTenant = currentTenant;
         _securitySettings = securitySettings.Value;
+        _pushNotifications = pushNotificationsFactory.Create();
     }
 
     public async Task<PaginationResponse<UserDetailsDto>> SearchAsync(UserListFilter filter, CancellationToken cancellationToken)

--- a/src/Infrastructure/Multitenancy/FSHTenantInfo.cs
+++ b/src/Infrastructure/Multitenancy/FSHTenantInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Finbuckle.MultiTenant;
+using FSH.WebApi.Application.Common.PushNotifications;
 using FSH.WebApi.Shared.Multitenancy;
 
 namespace FSH.WebApi.Infrastructure.Multitenancy;
@@ -45,6 +46,8 @@ public class FSHTenantInfo : ITenantInfo
     /// </summary>
     public string? Issuer { get; set; }
 
+    public TenantPushNotificationsSettings? PushNotificationsSettings { get; private set; }
+
     public void AddValidity(int months) =>
         ValidUpto = ValidUpto.AddMonths(months);
 
@@ -72,6 +75,9 @@ public class FSHTenantInfo : ITenantInfo
 
         IsActive = false;
     }
+
+    public void UpdatePushNotificationsSettings(TenantPushNotificationsSettings pushNotificationSettings) =>
+        PushNotificationsSettings = pushNotificationSettings;
 
     string? ITenantInfo.Id { get => Id; set => Id = value ?? throw new InvalidOperationException("Id can't be null."); }
     string? ITenantInfo.Identifier { get => Identifier; set => Identifier = value ?? throw new InvalidOperationException("Identifier can't be null."); }

--- a/src/Infrastructure/Multitenancy/TenantDbContext.cs
+++ b/src/Infrastructure/Multitenancy/TenantDbContext.cs
@@ -17,5 +17,6 @@ public class TenantDbContext : EFCoreStoreDbContext<FSHTenantInfo>
         base.OnModelCreating(modelBuilder);
 
         modelBuilder.Entity<FSHTenantInfo>().ToTable("Tenants", SchemaNames.MultiTenancy);
+        modelBuilder.Entity<FSHTenantInfo>().OwnsOne(t => t.PushNotificationsSettings);
     }
 }

--- a/src/Infrastructure/Multitenancy/TenantService.cs
+++ b/src/Infrastructure/Multitenancy/TenantService.cs
@@ -1,6 +1,7 @@
 ﻿using Finbuckle.MultiTenant;
 using FSH.WebApi.Application.Common.Exceptions;
 using FSH.WebApi.Application.Common.Persistence;
+using FSH.WebApi.Application.Common.PushNotifications;
 using FSH.WebApi.Application.Multitenancy;
 using FSH.WebApi.Infrastructure.Persistence;
 using FSH.WebApi.Infrastructure.Persistence.Initialization;
@@ -110,4 +111,12 @@ internal class TenantService : ITenantService
     private async Task<FSHTenantInfo> GetTenantInfoAsync(string id) =>
         await _tenantStore.TryGetAsync(id)
             ?? throw new NotFoundException(_t["{0} {1} Not Found.", typeof(FSHTenantInfo).Name, id]);
+
+    public async Task<string> UpdatePushNotificationInfo(string id, TenantPushNotificationsSettings pushNotificationsSettings)
+    {
+        var tenant = await GetTenantInfoAsync(id);
+        tenant.UpdatePushNotificationsSettings(pushNotificationsSettings);
+        await _tenantStore.TryUpdateAsync(tenant);
+        return _t["Tenant {0}'s Push Notification Settings Updated.", id];
+    }
 }

--- a/src/Infrastructure/PushNotifications/OneSignal/OneSignalConstants.cs
+++ b/src/Infrastructure/PushNotifications/OneSignal/OneSignalConstants.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Infrastructure.PushNotifications.OneSignal;
+
+public class OneSignalConstants
+{
+    public const string Url = "https://onesignal.com/api/v1/notifications";
+    public const string AuthHeader = "Authorization";
+    public const string AppId = "app_id";
+    public const string AppName = "app_name";
+    public const string Contents = "contents";
+    public const string Headings = "headings";
+    public const string LargeIcon = "large_icon";
+    public const string IncludedSegments = "included_segments";
+    public const string IncludeExternalUserIds = "include_external_user_ids";
+    public const string AllUsers = "All Users";
+    public const string ActiveUsers = "Active Users";
+    public const string InactiveUsers = "Inactive Users";
+}

--- a/src/Infrastructure/PushNotifications/OneSignal/OneSignalException.cs
+++ b/src/Infrastructure/PushNotifications/OneSignal/OneSignalException.cs
@@ -1,0 +1,18 @@
+﻿using FSH.WebApi.Application.Common.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Infrastructure.PushNotifications.OneSignal;
+
+// Thrown when request is succesfully done, but onesignal returns an error like "invalid player id"
+public class OneSignalException : CustomException
+{
+    public OneSignalException(string message, List<string>? errors)
+        : base(message, errors, HttpStatusCode.BadRequest)
+    {
+    }
+}

--- a/src/Infrastructure/PushNotifications/OneSignal/OneSignalService.cs
+++ b/src/Infrastructure/PushNotifications/OneSignal/OneSignalService.cs
@@ -1,0 +1,144 @@
+﻿using FSH.WebApi.Application.Common.Interfaces;
+using FSH.WebApi.Application.Common.PushNotifications;
+using FSH.WebApi.Infrastructure.Multitenancy;
+using Microsoft.Extensions.Logging;
+using System.Text;
+
+namespace FSH.WebApi.Infrastructure.PushNotifications.OneSignal;
+
+// Maybe use template method pattern with a BaseClass? It could be usefull if we add another push notification provider.
+public class OneSignalService : IPushNotificationsService
+{
+    private readonly TenantPushNotificationsSettings _tenantPushNotificationSettings;
+    private readonly IPushNotificationsTemplateFactory _template;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OneSignalService> _logger;
+    private readonly ISerializerService _serializer;
+
+    public OneSignalService(
+        FSHTenantInfo currentTenant,
+        IPushNotificationsTemplateFactory template,
+        IHttpClientFactory httpClientFactory,
+        ILogger<OneSignalService> logger,
+        ISerializerService serializer)
+    {
+        _tenantPushNotificationSettings = currentTenant.PushNotificationsSettings!; // null check is done in PushNotificationServiceFactory
+        _template = template;
+
+        _httpClient = httpClientFactory.CreateClient(PushNotificationsConstants.HttpClientName);
+        _httpClient.BaseAddress = new Uri(OneSignalConstants.Url);
+        _httpClient.DefaultRequestHeaders.Add(OneSignalConstants.AuthHeader, $"{_tenantPushNotificationSettings.AuthKey}");
+        _logger = logger;
+        _serializer = serializer;
+    }
+
+    public Task SendTo(string userId, ICollection<Message> messages)
+    {
+        string json = GenerateJson(
+            messages,
+            new KeyValuePair<string, ICollection<string>>(OneSignalConstants.IncludeExternalUserIds, new[] { userId }));
+
+        return SendHttpRequest(json);
+    }
+
+    public Task SendTo(string userId, string templateName)
+    {
+        var template = _template.Create(templateName);
+        return SendTo(userId, template.Messages);
+    }
+
+    public Task SendToAll(ICollection<Message> messages)
+    {
+        string json = GenerateJson(
+            messages,
+            new KeyValuePair<string, ICollection<string>>(OneSignalConstants.IncludedSegments, new[] { OneSignalConstants.AllUsers }));
+
+        return SendHttpRequest(json);
+    }
+
+    public Task SendToAll(string templateName)
+    {
+        var template = _template.Create(templateName);
+        return SendToAll(template.Messages);
+    }
+
+    public Task SendToActiveUsers(ICollection<Message> messages)
+    {
+        string json = GenerateJson(
+            messages,
+            new KeyValuePair<string, ICollection<string>>(OneSignalConstants.IncludedSegments, new[] { OneSignalConstants.ActiveUsers }));
+
+        return SendHttpRequest(json);
+    }
+
+    public Task SendToActiveUsers(string templateName)
+    {
+        var template = _template.Create(templateName);
+        return SendToActiveUsers(template.Messages);
+    }
+
+    public Task SendToInactiveUsers(ICollection<Message> messages)
+    {
+        string json = GenerateJson(
+            messages,
+            new KeyValuePair<string, ICollection<string>>(OneSignalConstants.IncludedSegments, new[] { OneSignalConstants.InactiveUsers }));
+
+        return SendHttpRequest(json);
+    }
+
+    public Task SendToInactiveUsers(string templateName)
+    {
+        var template = _template.Create(templateName);
+        return SendToInactiveUsers(template.Messages);
+    }
+
+    public async Task SendHttpRequest(string json)
+    {
+        try
+        {
+            _logger.LogDebug($"Sending push notification request to OneSignal with JSON: {json}");
+
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await _httpClient.PostAsync("", content);
+            response.EnsureSuccessStatusCode();
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            _logger.LogDebug($"OneSignal's response: {responseContent}");
+
+            if (responseContent.Contains("errors"))
+            {
+                throw new OneSignalException("OneSignal returned an error.", new List<string> { responseContent });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Error while sending push notification request to OneSignal with JSON: {json}");
+
+            throw;
+        }
+    }
+
+    private string GenerateJson(ICollection<Message> messages, KeyValuePair<string, ICollection<string>> receiver)
+    {
+        var notification = new Dictionary<string, object>
+        {
+            { OneSignalConstants.AppId, _tenantPushNotificationSettings.AppId },
+            { OneSignalConstants.AppName, _tenantPushNotificationSettings.Name },
+            { receiver.Key, receiver.Value },
+            { OneSignalConstants.Headings, new Dictionary<string, string>() },
+            { OneSignalConstants.Contents, new Dictionary<string, string>() },
+            { OneSignalConstants.LargeIcon, _tenantPushNotificationSettings.IconUrl }
+        };
+
+        var contentsEntry = (Dictionary<string, string>)notification[OneSignalConstants.Contents];
+        var headingsEntry = (Dictionary<string, string>)notification[OneSignalConstants.Headings];
+
+        foreach (Message message in messages)
+        {
+            contentsEntry.Add(message.Language, message.Content);
+            headingsEntry.Add(message.Language, message.Heading);
+        }
+
+        return _serializer.Serialize(notification);
+    }
+}

--- a/src/Infrastructure/PushNotifications/PushNotificationsConstants.cs
+++ b/src/Infrastructure/PushNotifications/PushNotificationsConstants.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Infrastructure.PushNotifications;
+public class PushNotificationsConstants
+{
+    public const string HttpClientName = "PushNotificationsHttpClient";
+}

--- a/src/Infrastructure/PushNotifications/PushNotificationsServiceFactory.cs
+++ b/src/Infrastructure/PushNotifications/PushNotificationsServiceFactory.cs
@@ -1,0 +1,36 @@
+﻿using FSH.WebApi.Application.Common.PushNotifications;
+using FSH.WebApi.Infrastructure.Multitenancy;
+using FSH.WebApi.Infrastructure.PushNotifications.OneSignal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FSH.WebApi.Infrastructure.PushNotifications;
+
+public class PushNotificationsServiceFactory : IPushNotificationServiceFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly FSHTenantInfo _currentTenant;
+
+    public PushNotificationsServiceFactory(IServiceProvider serviceProvider, FSHTenantInfo currentTenant)
+    {
+        _serviceProvider = serviceProvider;
+        _currentTenant = currentTenant;
+    }
+
+    // Resolve the push notification service based on the current tenant's push notification provider if exists.
+    public IPushNotificationsService? Create()
+    {
+        if (_currentTenant?.PushNotificationsSettings?.Provider is { } provider)
+        {
+            return provider switch
+            {
+                PushNotificationsProvider.OneSignal => _serviceProvider.GetRequiredService<OneSignalService>(),
+
+                // PushNotificationProvider.Firebase => _serviceProvider.GetRequiredService<IFirebaseService>(),
+
+                _ => throw new NotImplementedException($"Push notification service for {provider.GetType().Name} is not implemented.")
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/Infrastructure/PushNotifications/PushNotificationsTemplateFactory.cs
+++ b/src/Infrastructure/PushNotifications/PushNotificationsTemplateFactory.cs
@@ -1,0 +1,41 @@
+﻿using FSH.WebApi.Application.Common.Interfaces;
+using FSH.WebApi.Application.Common.PushNotifications;
+using Microsoft.Extensions.Logging;
+
+namespace FSH.WebApi.Infrastructure.PushNotifications;
+
+public class PushNotificationsTemplateFactory : IPushNotificationsTemplateFactory
+{
+    private readonly ISerializerService _serializer;
+    private readonly ILogger<PushNotificationsTemplateFactory> _logger;
+
+    public PushNotificationsTemplateFactory(ISerializerService serializer, ILogger<PushNotificationsTemplateFactory> logger)
+    {
+        _serializer = serializer;
+        _logger = logger;
+    }
+
+    public PushNotificationTemplate Create(string templateName)
+    {
+        string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+        string tmplFolder = Path.Combine(baseDirectory, "PushNotifications Templates");
+        string filePath = Path.Combine(tmplFolder, $"{templateName}.json");
+
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException("Template file not found.", filePath);
+        }
+
+        string json = File.ReadAllText(filePath);
+
+        try
+        {
+            return _serializer.Deserialize<PushNotificationTemplate>(json);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Error deserializing template file: {filePath}");
+            throw;
+        }
+    }
+}

--- a/src/Infrastructure/PushNotifications/Startup.cs
+++ b/src/Infrastructure/PushNotifications/Startup.cs
@@ -1,0 +1,30 @@
+﻿using FSH.WebApi.Application.Common.PushNotifications;
+using FSH.WebApi.Infrastructure.PushNotifications.OneSignal;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSH.WebApi.Infrastructure.PushNotifications;
+
+public static class Startup
+{
+    public static IServiceCollection AddPushNotifications(this IServiceCollection services)
+    {
+        // GetRequiredService<OneSignalService>() is throwing exception even when IPushNotificiationService is ITransientService,
+        // I could add IOneSignalService:ITransientService and use auto service registration but,
+        // wanted to prevent direct injections instead of factory.Create();
+        services.AddTransient<OneSignalService>();
+
+        services.AddHttpClient(PushNotificationsConstants.HttpClientName, conf =>
+        {
+            // I could put basepath, authKey etc. here,
+            // but push notification provider can vary accross tenants
+            // and also authKey will be different for each tenant
+        });
+
+        return services;
+    }
+}

--- a/src/Infrastructure/Startup.cs
+++ b/src/Infrastructure/Startup.cs
@@ -15,6 +15,7 @@ using FSH.WebApi.Infrastructure.Notifications;
 using FSH.WebApi.Infrastructure.OpenApi;
 using FSH.WebApi.Infrastructure.Persistence;
 using FSH.WebApi.Infrastructure.Persistence.Initialization;
+using FSH.WebApi.Infrastructure.PushNotifications;
 using FSH.WebApi.Infrastructure.SecurityHeaders;
 using FSH.WebApi.Infrastructure.Validations;
 using MediatR;
@@ -52,6 +53,7 @@ public static class Startup
             .AddPersistence()
             .AddRequestLogging(config)
             .AddRouting(options => options.LowercaseUrls = true)
+            .AddPushNotifications()
             .AddServices();
     }
 

--- a/src/Migrators/Migrators.PostgreSQL/Migrations/Tenant/20230719110621_push_notifications.Designer.cs
+++ b/src/Migrators/Migrators.PostgreSQL/Migrations/Tenant/20230719110621_push_notifications.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FSH.WebApi.Infrastructure.Multitenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Migrators.PostgreSQL.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230719110621_push_notifications")]
+    partial class push_notifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrators/Migrators.PostgreSQL/Migrations/Tenant/20230719110621_push_notifications.cs
+++ b/src/Migrators/Migrators.PostgreSQL/Migrations/Tenant/20230719110621_push_notifications.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Migrators.PostgreSQL.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class push_notifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PushNotificationsSettings_AppId",
+                schema: "MultiTenancy",
+                table: "Tenants",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PushNotificationsSettings_AuthKey",
+                schema: "MultiTenancy",
+                table: "Tenants",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PushNotificationsSettings_IconUrl",
+                schema: "MultiTenancy",
+                table: "Tenants",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PushNotificationsSettings_Name",
+                schema: "MultiTenancy",
+                table: "Tenants",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PushNotificationsSettings_Provider",
+                schema: "MultiTenancy",
+                table: "Tenants",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PushNotificationsSettings_AppId",
+                schema: "MultiTenancy",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "PushNotificationsSettings_AuthKey",
+                schema: "MultiTenancy",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "PushNotificationsSettings_IconUrl",
+                schema: "MultiTenancy",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "PushNotificationsSettings_Name",
+                schema: "MultiTenancy",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "PushNotificationsSettings_Provider",
+                schema: "MultiTenancy",
+                table: "Tenants");
+        }
+    }
+}


### PR DESCRIPTION
# Flexible Push Notifications

This PR brings in the functionality of flexible push notifications, enabling each tenant to have their own push notification provider.

Here is a summary of the changes and new features:

- Implemented a flexible and generic push notification system.
- Provided the ability to send push notifications via predefined templates, which can be found under Host/PushNotifications Templates.
- Added capability to send custom push notification messages.
- Included the popular provider, OneSignal. More providers can be easily added in the future.
- Created an injectable push notification service via ``IPushNotificationsServiceFactory.Create()``. This method resolves a push notification provider service based on the current tenant's Push Notifications provider.
- Included a named ``HttpClient`` in services for push notifications purposes, which can be used for sending requests to OneSignal and other providers.
- Updated the ``FSHTenantInfo`` entity to include ``PushNotificationsSettings`` as an owned entity.
- Added a new API endpoint under ``TenantsController`` to update a tenant's ``PushNotificationsSettings``.
- Provided an example under ``UpdateProductRequest`` showing how to send push notifications to all users via a template.
- Added a custom notification send API under ``UsersController``, to send custom push notifications to a specific user.
- Introduced a new Permission type for sending push notifications.
- Included an example template ``product-updated.json``.
- Applied a migration to the tenant context due to the ``FSHTenantInfo`` having a new owned entity now.

Please let me know if you have any questions or need further information. I appreciate your time in reviewing this PR.

