### PR TITLE
fix: Add missing authorization to Identity endpoints

### DIFF
--- a/src/BuildingBlocks/Shared/Identity/IdentityPermissionConstants.cs
+++ b/src/BuildingBlocks/Shared/Identity/IdentityPermissionConstants.cs
@@ -8,6 +8,7 @@ public static class IdentityPermissionConstants
         public const string Create = "Permissions.Users.Create";
         public const string Update = "Permissions.Users.Update";
         public const string Delete = "Permissions.Users.Delete";
+        public const string ManageRoles = "Permissions.Users.ManageRoles";
     }
 
     public static class Roles

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/AssignUserRoles/AssignUserRolesEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/AssignUserRoles/AssignUserRolesEndpoint.cs
@@ -1,4 +1,6 @@
-﻿using FSH.Modules.Identity.Contracts.v1.Users.AssignUserRoles;
+﻿using FSH.Framework.Shared.Identity;
+using FSH.Framework.Shared.Identity.Authorization;
+using FSH.Modules.Identity.Contracts.v1.Users.AssignUserRoles;
 using Mediator;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -27,6 +29,7 @@ public static class AssignUserRolesEndpoint
         })
         .WithName("AssignUserRoles")
         .WithSummary("Assign roles to user")
-        .WithDescription("Assign one or more roles to a user.");
+        .WithDescription("Assign one or more roles to a user.")
+        .RequirePermission(IdentityPermissionConstants.Users.ManageRoles);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/ChangePassword/ChangePasswordEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/ChangePassword/ChangePasswordEndpoint.cs
@@ -21,6 +21,7 @@ public static class ChangePasswordEndpoint
         })
         .WithName("ChangePassword")
         .WithSummary("Change password")
-        .WithDescription("Change the current user's password.");
+        .WithDescription("Change the current user's password.")
+        .RequireAuthorization();
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserPermissions/GetUserPermissionsEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserPermissions/GetUserPermissionsEndpoint.cs
@@ -1,5 +1,7 @@
 using System.Security.Claims;
 using FSH.Framework.Core.Exceptions;
+using FSH.Framework.Shared.Identity;
+using FSH.Framework.Shared.Identity.Authorization;
 using FSH.Framework.Shared.Identity.Claims;
 using FSH.Modules.Identity.Contracts.v1.Users.GetUserPermissions;
 using Mediator;
@@ -24,6 +26,7 @@ public static class GetUserPermissionsEndpoint
         })
         .WithName("GetCurrentUserPermissions")
         .WithSummary("Get current user permissions")
-        .WithDescription("Retrieve permissions for the authenticated user.");
+        .WithDescription("Retrieve permissions for the authenticated user.")
+        .RequirePermission(IdentityPermissionConstants.Users.View);
     }
 }

--- a/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserProfile/GetUserProfileEndpoint.cs
+++ b/src/Modules/Identity/Modules.Identity/Features/v1/Users/GetUserProfile/GetUserProfileEndpoint.cs
@@ -24,6 +24,7 @@ public static class GetUserProfileEndpoint
         })
         .WithName("GetCurrentUserProfile")
         .WithSummary("Get current user profile")
-        .WithDescription("Retrieve the authenticated user's profile from the access token.");
+        .WithDescription("Retrieve the authenticated user's profile from the access token.")
+        .RequireAuthorization();
     }
 }


### PR DESCRIPTION
## Summary
This PR adds missing authorization checks to 4 Identity module endpoints that were previously accessible without proper authentication/authorization.

## Changes

### Endpoints Updated:
1. **ChangePasswordEndpoint** - Added `.RequireAuthorization()` (user must be logged in to change their password)
2. **GetUserProfileEndpoint** - Added `.RequireAuthorization()` (user must be logged in to view their profile)
3. **AssignUserRolesEndpoint** - Added `.RequirePermission(IdentityPermissionConstants.Users.ManageRoles)` (only users with ManageRoles permission can assign roles)
4. **GetUserPermissionsEndpoint** - Added `.RequirePermission(IdentityPermissionConstants.Users.View)` (only users with View permission can see user permissions)

### Permission Constants:
- Added new `Users.ManageRoles` permission constant to `IdentityPermissionConstants`

## Security Impact
These changes ensure that:
- Anonymous users cannot access profile/password endpoints
- Only authorized administrators can manage user roles
- User permissions are only visible to those with proper access

## Testing
- Followed existing FSH endpoint authorization patterns
- Consistent with other Identity module endpoints (e.g., GetUserRoles, DeleteUser)