### PR TITLE
fix(multitenancy): update migrations assembly configuration in Tenant…

### DIFF
--- a/src/Modules/Multitenancy/Modules.Multitenancy/Data/TenantDbContextFactory.cs
+++ b/src/Modules/Multitenancy/Modules.Multitenancy/Data/TenantDbContextFactory.cs
@@ -19,7 +19,8 @@ public sealed class TenantDbContextFactory : IDesignTimeDbContextFactory<TenantD
         var provider = configuration["DatabaseOptions:Provider"] ?? "POSTGRESQL";
         var connectionString = configuration["DatabaseOptions:ConnectionString"]
             ?? "Host=localhost;Database=fsh-tenant;Username=postgres;Password=postgres";
-
+        var migrationsAssembly = configuration["DatabaseOptions:MigrationsAssembly"]
+            ?? "FSH.Playground.Migrations.PostgreSQL";
         var optionsBuilder = new DbContextOptionsBuilder<TenantDbContext>();
 
         switch (provider.ToUpperInvariant())
@@ -27,7 +28,7 @@ public sealed class TenantDbContextFactory : IDesignTimeDbContextFactory<TenantD
             case "POSTGRESQL":
                 optionsBuilder.UseNpgsql(
                     connectionString,
-                    b => b.MigrationsAssembly("FSH.Playground.Migrations.PostgreSQL"));
+                    b => b.MigrationsAssembly(migrationsAssembly));
                 break;
             default:
                 throw new NotSupportedException($"Database provider '{provider}' is not supported for TenantDbContext migrations.");


### PR DESCRIPTION
## Summary
Refactored `TenantDbContextFactory.cs` in the Multitenancy module to read migrations assembly from configuration, with a fallback to the original hardcoded value. This fixes the issue identified in #1198

## Changes
Updated to read from the `DatabaseOptions:MigrationAssembly` configuration value used elsewhere, with a fallback to the original Playground value when this isn't present.

```csharp
var migrationsAssembly = configuration["DatabaseOptions:MigrationsAssembly"]
            ?? "FSH.Playground.Migrations.PostgreSQL";
````

```csharp
b => b.MigrationsAssembly(migrationsAssembly));
```

## Files Changed
- src/Modules/Multitenancy/Modules.Multitenancy/Data/TenantDbContextFactory.cs

## Build Status
✅ 0 errors, 0 new warnings

Closed #1198 