### PR TITLE
fix(migrator): resolve JwtOptions validation failure in Aspire orchestrator

### DIFF
--- a/src/Host/FSH.Starter.DbMigrator/Program.cs
+++ b/src/Host/FSH.Starter.DbMigrator/Program.cs
@@ -49,6 +49,12 @@ if (cli.Help)
 
 var builder = Host.CreateApplicationBuilder(args);
 
+// In local development (dotnet run), the working directory is the project folder,
+// but appsettings.json is linked and copied to the output directory.
+// We explicitly load it from AppContext.BaseDirectory so IdentityModule's JwtOptions validate.
+builder.Configuration.AddJsonFile(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), optional: true);
+builder.Configuration.AddJsonFile(Path.Combine(AppContext.BaseDirectory, $"appsettings.{builder.Environment.EnvironmentName}.json"), optional: true);
+
 // Fail-fast before option-validation runs at host build time: if the operator
 // forgot to set DatabaseOptions__ConnectionString, give them a single clear
 // line they'll actually read rather than a validation exception stack trace.

--- a/src/Host/FSH.Starter.DbMigrator/Program.cs
+++ b/src/Host/FSH.Starter.DbMigrator/Program.cs
@@ -46,7 +46,6 @@ if (cli.Help)
     await Console.Out.WriteLineAsync(MigratorCommand.HelpText).ConfigureAwait(false);
     return 0;
 }
-
 var builder = Host.CreateApplicationBuilder(args);
 
 // In local development (dotnet run), the working directory is the project folder,
@@ -54,6 +53,10 @@ var builder = Host.CreateApplicationBuilder(args);
 // We explicitly load it from AppContext.BaseDirectory so IdentityModule's JwtOptions validate.
 builder.Configuration.AddJsonFile(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), optional: true);
 builder.Configuration.AddJsonFile(Path.Combine(AppContext.BaseDirectory, $"appsettings.{builder.Environment.EnvironmentName}.json"), optional: true);
+
+// Re-add environment variables and command line args so they maintain priority over the manually added JSON files.
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
 
 // Fail-fast before option-validation runs at host build time: if the operator
 // forgot to set DatabaseOptions__ConnectionString, give them a single clear


### PR DESCRIPTION
This PR fixes an issue where fsh-db-migrator silently crashes with OptionsValidationException when running via Aspire. In Aspire (dotnet run), the migrator's working directory is the project directory, so it fails to find appsettings.json (which is copied to the build output directory). Because IdentityModule registers JwtOptions with .ValidateOnStart(), the missing configuration causes the DI container build to fail entirely. Because AppHost.cs was recently updated to use .WaitForCompletion(migrator), this crash causes the fsh-api resource to wait indefinitely, hanging the entire Aspire orchestration. Fix: Explicitly load appsettings.json and appsettings.{Environment}.json from AppContext.BaseDirectory so that JwtOptions validation succeeds. Re-apply AddEnvironmentVariables() and AddCommandLine(args) immediately afterwards. This ensures that Aspire's dynamically injected environment variables maintain their intended priority and are not overridden by the hardcoded local connection strings in the loaded JSON files.